### PR TITLE
Rewrite handling of scheduled miniblocks. Fix handling of invalid scheduled transactions

### DIFF
--- a/cmd/rosetta/cli.go
+++ b/cmd/rosetta/cli.go
@@ -119,11 +119,6 @@ VERSION:
 		Usage: "Specifies the symbol of the native currency (must be EGLD for mainnet, XeGLD for testnet and devnet).",
 		Value: "EGLD",
 	}
-
-	cliObserveNotFinalBlocks = cli.BoolFlag{
-		Name:  "observe-not-final-blocks",
-		Usage: "Observe not final blocks, as well",
-	}
 )
 
 func getAllCliFlags() []cli.Flag {
@@ -144,7 +139,6 @@ func getAllCliFlags() []cli.Flag {
 		cliFlagMinGasLimit,
 		cliFlagGasPerDataByte,
 		cliFlagNativeCurrencySymbol,
-		cliObserveNotFinalBlocks,
 	}
 }
 
@@ -166,7 +160,6 @@ type parsedCliFlags struct {
 	minGasLimit                 uint64
 	gasPerDataByte              uint64
 	nativeCurrencySymbol        string
-	observeNotFinalBlocks       bool
 }
 
 func getParsedCliFlags(ctx *cli.Context) parsedCliFlags {
@@ -188,6 +181,5 @@ func getParsedCliFlags(ctx *cli.Context) parsedCliFlags {
 		minGasLimit:                 ctx.GlobalUint64(cliFlagMinGasLimit.Name),
 		gasPerDataByte:              ctx.GlobalUint64(cliFlagGasPerDataByte.Name),
 		nativeCurrencySymbol:        ctx.GlobalString(cliFlagNativeCurrencySymbol.Name),
-		observeNotFinalBlocks:       ctx.GlobalBool(cliObserveNotFinalBlocks.Name),
 	}
 }

--- a/cmd/rosetta/main.go
+++ b/cmd/rosetta/main.go
@@ -62,7 +62,6 @@ func startRosetta(ctx *cli.Context) error {
 		MinGasLimit:                 cliFlags.minGasLimit,
 		NativeCurrencySymbol:        cliFlags.nativeCurrencySymbol,
 		GenesisBlockHash:            cliFlags.genesisBlock,
-		ObserveNotFinalBlocks:       cliFlags.observeNotFinalBlocks,
 	})
 	if err != nil {
 		return err

--- a/server/provider/blocks.go
+++ b/server/provider/blocks.go
@@ -1,0 +1,21 @@
+package provider
+
+import "github.com/ElrondNetwork/elrond-proxy-go/data"
+
+func removeMiniblocks(block *data.Block, shouldRemove func(miniblock *data.MiniBlock) bool) {
+	miniblocksToKeep := make([]*data.MiniBlock, 0, len(block.MiniBlocks))
+
+	for _, miniblock := range block.MiniBlocks {
+		if shouldRemove(miniblock) {
+			continue
+		}
+
+		miniblocksToKeep = append(miniblocksToKeep, miniblock)
+	}
+
+	block.MiniBlocks = miniblocksToKeep
+}
+
+func appendMiniblocksToBlock(block *data.Block, miniblocks []*data.MiniBlock) {
+	block.MiniBlocks = append(block.MiniBlocks, miniblocks...)
+}

--- a/server/provider/blocks.go
+++ b/server/provider/blocks.go
@@ -2,7 +2,7 @@ package provider
 
 import "github.com/ElrondNetwork/elrond-proxy-go/data"
 
-func removeMiniblocks(block *data.Block, shouldRemove func(miniblock *data.MiniBlock) bool) {
+func removeMiniblocksFromBlock(block *data.Block, shouldRemove func(miniblock *data.MiniBlock) bool) {
 	miniblocksToKeep := make([]*data.MiniBlock, 0, len(block.MiniBlocks))
 
 	for _, miniblock := range block.MiniBlocks {

--- a/server/provider/blocks_test.go
+++ b/server/provider/blocks_test.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveMiniblocksFromBlock(t *testing.T) {
+	block := &data.Block{
+		MiniBlocks: []*data.MiniBlock{
+			{Hash: "aaaa", SourceShard: 7},
+			{Hash: "bbbb", SourceShard: 8},
+			{Hash: "aabb", SourceShard: 7},
+			{Hash: "abba", SourceShard: 8},
+		},
+	}
+
+	shouldRemove := func(miniblock *data.MiniBlock) bool {
+		return miniblock.SourceShard == 8
+	}
+
+	removeMiniblocksFromBlock(block, shouldRemove)
+	require.Len(t, block.MiniBlocks, 2)
+	require.Equal(t, "aaaa", block.MiniBlocks[0].Hash)
+	require.Equal(t, "aabb", block.MiniBlocks[1].Hash)
+}
+
+func TestAppendMiniblocksToBlock(t *testing.T) {
+	block := &data.Block{
+		MiniBlocks: []*data.MiniBlock{
+			{Hash: "aaaa"},
+			{Hash: "bbbb"},
+		},
+	}
+
+	appendMiniblocksToBlock(block, []*data.MiniBlock{{Hash: "abcd"}, {Hash: "dcba"}})
+	require.Len(t, block.MiniBlocks, 4)
+	require.Equal(t, "abcd", block.MiniBlocks[2].Hash)
+	require.Equal(t, "dcba", block.MiniBlocks[3].Hash)
+}

--- a/server/provider/scheduledMiniblocks.go
+++ b/server/provider/scheduledMiniblocks.go
@@ -21,41 +21,25 @@ func (provider *networkProvider) simplifyBlockWithScheduledTransactions(block *d
 	}
 
 	// Discard "processed" miniblocks in block N, since they already produced effects in N-1
-	discardProcessedMiniblocks(block)
+	removeProcessedMiniblocksOfBlock(block)
 
 	// Move "processed" miniblocks from N+1 to N
 	processedMiniblocksInNextBlock := findProcessedMiniblocks(nextBlock)
 	appendMiniblocksToBlock(block, processedMiniblocksInNextBlock)
 
-	// Find "invalid" transactions that are "final" in N
-	invalidTxsInBlock := findInvalidTransactions(block)
-	// If present in N-1, discard them
-	scheduledTxsHashesPreviousBlock := findScheduledTransactionsHashes(previousBlock)
-	invalidTxsInBlock = discardTransactions(invalidTxsInBlock, scheduledTxsHashesPreviousBlock)
-
-	// Find "invalid" transactions in N+1 that are "scheduled" in N
-	invalidTxsInNextBlock := findInvalidTransactions(nextBlock)
-	scheduledTxsHashesInBlock := findScheduledTransactionsHashes(block)
-	invalidTxsScheduledInBlock := filterTransactions(invalidTxsInNextBlock, scheduledTxsHashesInBlock)
-
-	// Duplication might occur, since a block can contain two "invalid" miniblocks,
-	// one added to block, one saved in the receipts unit (and they have different hashes).
-	invalidTxs := append(invalidTxsInBlock, invalidTxsScheduledInBlock...)
-	invalidTxs = deduplicateTransactions(invalidTxs)
-
 	// Build an artificial miniblock holding the "invalid" transactions that produced their effects in block N,
 	// and replace the existing (one or two "invalid" miniblocks).
-	discardInvalidMiniblocks(block)
-	appendMiniblocksToBlock(block, []*data.MiniBlock{
-		{
-			Type:         dataBlock.InvalidBlock.String(),
-			Transactions: invalidTxs,
-		},
-	})
+	invalidTxs := gatherInvalidTransactions(previousBlock, block, nextBlock)
+	invalidMiniblock := &data.MiniBlock{
+		Type:         dataBlock.InvalidBlock.String(),
+		Transactions: invalidTxs,
+	}
+	removeInvalidMiniblocks(block)
+	appendMiniblocksToBlock(block, []*data.MiniBlock{invalidMiniblock})
 
-	// Also discard "scheduled" miniblocks of N, since we've already brought the "processed" ones from N+1,
+	// Discard "scheduled" miniblocks of N, since we've already brought the "processed" ones from N+1,
 	// and also handled the "invalid" ones.
-	discardScheduledMiniblocks(block)
+	removeScheduledMiniblocks(block)
 
 	return nil
 }
@@ -70,10 +54,42 @@ func hasOnlyNormalMiniblocks(block *data.Block) bool {
 	return true
 }
 
-func discardProcessedMiniblocks(block *data.Block) {
-	block.MiniBlocks = discardMiniblocks(block.MiniBlocks, func(miniblock *data.MiniBlock) bool {
+func removeProcessedMiniblocksOfBlock(block *data.Block) {
+	removeMiniblocks(block, func(miniblock *data.MiniBlock) bool {
 		return miniblock.ProcessingType == string(Processed)
 	})
+}
+
+func removeScheduledMiniblocks(block *data.Block) {
+	removeMiniblocks(block, func(miniblock *data.MiniBlock) bool {
+		return miniblock.ProcessingType == string(Scheduled)
+	})
+}
+
+func removeInvalidMiniblocks(block *data.Block) {
+	removeMiniblocks(block, func(miniblock *data.MiniBlock) bool {
+		return miniblock.Type == dataBlock.InvalidBlock.String()
+	})
+}
+
+func gatherInvalidTransactions(previousBlock *data.Block, block *data.Block, nextBlock *data.Block) []*data.FullTransaction {
+	// Find "invalid" transactions that are "final" in N
+	invalidTxsInBlock := findInvalidTransactions(block)
+	// If also present in N-1, discard them
+	scheduledTxsHashesPreviousBlock := findScheduledTransactionsHashes(previousBlock)
+	invalidTxsInBlock = discardTransactions(invalidTxsInBlock, scheduledTxsHashesPreviousBlock)
+
+	// Find "invalid" transactions in N+1 that are "scheduled" in N
+	invalidTxsInNextBlock := findInvalidTransactions(nextBlock)
+	scheduledTxsHashesInBlock := findScheduledTransactionsHashes(block)
+	invalidTxsScheduledInBlock := filterTransactions(invalidTxsInNextBlock, scheduledTxsHashesInBlock)
+
+	// Duplication might occur, since a block can contain two "invalid" miniblocks,
+	// one added to block body, one saved in the receipts unit (at times, they have different content, different hashes).
+	invalidTxs := append(invalidTxsInBlock, invalidTxsScheduledInBlock...)
+	invalidTxs = deduplicateTransactions(invalidTxs)
+
+	return invalidTxs
 }
 
 func findScheduledTransactionsHashes(block *data.Block) map[string]struct{} {
@@ -102,10 +118,6 @@ func findProcessedMiniblocks(block *data.Block) []*data.MiniBlock {
 	return foundMiniblocks
 }
 
-func appendMiniblocksToBlock(block *data.Block, miniblocks []*data.MiniBlock) {
-	block.MiniBlocks = append(block.MiniBlocks, miniblocks...)
-}
-
 func findInvalidTransactions(block *data.Block) []*data.FullTransaction {
 	invalidTxs := make([]*data.FullTransaction, 0)
 
@@ -118,75 +130,4 @@ func findInvalidTransactions(block *data.Block) []*data.FullTransaction {
 	}
 
 	return invalidTxs
-}
-
-func discardTransactions(txs []*data.FullTransaction, txsHashesToDiscard map[string]struct{}) []*data.FullTransaction {
-	txsToKeep := make([]*data.FullTransaction, 0, len(txs))
-
-	for _, tx := range txs {
-		_, shouldDiscard := txsHashesToDiscard[tx.Hash]
-		if shouldDiscard {
-			continue
-		}
-
-		txsToKeep = append(txsToKeep, tx)
-	}
-
-	return txsToKeep
-}
-
-func filterTransactions(txs []*data.FullTransaction, txsHashesToKeep map[string]struct{}) []*data.FullTransaction {
-	txsToKeep := make([]*data.FullTransaction, 0, len(txs))
-
-	for _, tx := range txs {
-		_, shouldKeep := txsHashesToKeep[tx.Hash]
-		if shouldKeep {
-			txsToKeep = append(txsToKeep, tx)
-		}
-	}
-
-	return txsToKeep
-}
-
-func deduplicateTransactions(txs []*data.FullTransaction) []*data.FullTransaction {
-	deduplicatedTxs := make([]*data.FullTransaction, 0, len(txs))
-	seenTxsHashes := make(map[string]struct{})
-
-	for _, tx := range txs {
-		_, alreadySeen := seenTxsHashes[tx.Hash]
-		if alreadySeen {
-			continue
-		}
-
-		deduplicatedTxs = append(deduplicatedTxs, tx)
-		seenTxsHashes[tx.Hash] = struct{}{}
-	}
-
-	return deduplicatedTxs
-}
-
-func discardScheduledMiniblocks(block *data.Block) {
-	block.MiniBlocks = discardMiniblocks(block.MiniBlocks, func(miniblock *data.MiniBlock) bool {
-		return miniblock.ProcessingType == string(Scheduled)
-	})
-}
-
-func discardInvalidMiniblocks(block *data.Block) {
-	block.MiniBlocks = discardMiniblocks(block.MiniBlocks, func(miniblock *data.MiniBlock) bool {
-		return miniblock.Type == dataBlock.InvalidBlock.String()
-	})
-}
-
-func discardMiniblocks(miniblocks []*data.MiniBlock, predicate func(miniblock *data.MiniBlock) bool) []*data.MiniBlock {
-	miniblocksToKeep := make([]*data.MiniBlock, 0, len(miniblocks))
-
-	for _, miniblock := range miniblocks {
-		if predicate(miniblock) {
-			continue
-		}
-
-		miniblocksToKeep = append(miniblocksToKeep, miniblock)
-	}
-
-	return miniblocksToKeep
 }

--- a/server/provider/scheduledMiniblocks.go
+++ b/server/provider/scheduledMiniblocks.go
@@ -55,19 +55,19 @@ func hasOnlyNormalMiniblocks(block *data.Block) bool {
 }
 
 func removeProcessedMiniblocksOfBlock(block *data.Block) {
-	removeMiniblocks(block, func(miniblock *data.MiniBlock) bool {
+	removeMiniblocksFromBlock(block, func(miniblock *data.MiniBlock) bool {
 		return miniblock.ProcessingType == string(Processed)
 	})
 }
 
 func removeScheduledMiniblocks(block *data.Block) {
-	removeMiniblocks(block, func(miniblock *data.MiniBlock) bool {
+	removeMiniblocksFromBlock(block, func(miniblock *data.MiniBlock) bool {
 		return miniblock.ProcessingType == string(Scheduled)
 	})
 }
 
 func removeInvalidMiniblocks(block *data.Block) {
-	removeMiniblocks(block, func(miniblock *data.MiniBlock) bool {
+	removeMiniblocksFromBlock(block, func(miniblock *data.MiniBlock) bool {
 		return miniblock.Type == dataBlock.InvalidBlock.String()
 	})
 }

--- a/server/provider/scheduledMiniblocks_test.go
+++ b/server/provider/scheduledMiniblocks_test.go
@@ -1,0 +1,136 @@
+package provider
+
+import (
+	"testing"
+
+	dataBlock "github.com/ElrondNetwork/elrond-go-core/data/block"
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatherInvalidTransactions(t *testing.T) {
+	// Block N-1
+	previousBlock := &data.Block{
+		MiniBlocks: []*data.MiniBlock{
+			{
+				Type: dataBlock.InvalidBlock.String(),
+				Transactions: []*data.FullTransaction{
+					{Hash: "aaaa"},
+				},
+			},
+		},
+	}
+
+	// Block N
+	block := &data.Block{
+		MiniBlocks: []*data.MiniBlock{
+			{
+				ProcessingType: string(Scheduled),
+				Transactions: []*data.FullTransaction{
+					{Hash: "bbbb"},
+					{Hash: "cccc"},
+				},
+			},
+			{
+				Type: dataBlock.InvalidBlock.String(),
+				Transactions: []*data.FullTransaction{
+					{Hash: "bbbb"},
+				},
+			},
+		},
+	}
+
+	// Block N+1
+	nextBlock := &data.Block{
+		MiniBlocks: []*data.MiniBlock{
+			{
+				ProcessingType: string(Processed),
+				Transactions: []*data.FullTransaction{
+					{Hash: "cccc"},
+				},
+			},
+			{
+				Type: dataBlock.InvalidBlock.String(),
+				Transactions: []*data.FullTransaction{
+					{Hash: "bbbb"},
+					{Hash: "eeee"},
+				},
+			},
+		},
+	}
+
+	// "aaaa" is ignored for N, since it produces effects in N-1
+	// "eeee" is ignored for N, since it produces effects in N+1
+	invalidTxs := gatherInvalidTransactions(previousBlock, block, nextBlock)
+	require.Len(t, invalidTxs, 1)
+	require.Equal(t, "bbbb", invalidTxs[0].Hash)
+}
+
+func TestGatherInvalidTransactions_WhenIntraShardIsMissingInPreviousBlock(t *testing.T) {
+	// Edge case on start of epoch.
+
+	// Block N-1
+	previousBlock := &data.Block{
+		MiniBlocks: []*data.MiniBlock{
+			{
+				ProcessingType: string(Scheduled),
+				Transactions: []*data.FullTransaction{
+					{Hash: "aaaa"},
+				},
+			},
+			// "aaaa" is an invalid transaction that produces effects in N-1,
+			// but the intra-shard, "invalid" miniblock is missing (not provided by the API).
+		},
+	}
+
+	// Block N
+	block := &data.Block{
+		MiniBlocks: []*data.MiniBlock{
+			{
+				ProcessingType: string(Scheduled),
+				Transactions: []*data.FullTransaction{
+					{Hash: "abab"},
+					{Hash: "cccc"},
+				},
+			},
+			{
+				Type: dataBlock.InvalidBlock.String(),
+				Transactions: []*data.FullTransaction{
+					{Hash: "aaaa"},
+				},
+			},
+			{
+				// Intra-shard miniblock, holds both "aaaa" (scheduled in N-1, with effects in N)
+				// and "abab" (scheduled in N, with effects in N)
+				Type: dataBlock.InvalidBlock.String(),
+				Transactions: []*data.FullTransaction{
+					{Hash: "aaaa"},
+					{Hash: "abab"},
+				},
+			},
+		},
+	}
+
+	// Block N+1
+	nextBlock := &data.Block{
+		MiniBlocks: []*data.MiniBlock{
+			{
+				ProcessingType: string(Processed),
+				Transactions: []*data.FullTransaction{
+					{Hash: "cccc"},
+				},
+			},
+			{
+				Type: dataBlock.InvalidBlock.String(),
+				Transactions: []*data.FullTransaction{
+					{Hash: "abab"},
+				},
+			},
+		},
+	}
+
+	// "aaaa" is ignored for N, since it produces effects in N-1
+	invalidTxs := gatherInvalidTransactions(previousBlock, block, nextBlock)
+	require.Len(t, invalidTxs, 1)
+	require.Equal(t, "abab", invalidTxs[0].Hash)
+}

--- a/server/provider/transactions.go
+++ b/server/provider/transactions.go
@@ -1,0 +1,48 @@
+package provider
+
+import "github.com/ElrondNetwork/elrond-proxy-go/data"
+
+func discardTransactions(txs []*data.FullTransaction, txsHashesToDiscard map[string]struct{}) []*data.FullTransaction {
+	txsToKeep := make([]*data.FullTransaction, 0, len(txs))
+
+	for _, tx := range txs {
+		_, shouldDiscard := txsHashesToDiscard[tx.Hash]
+		if shouldDiscard {
+			continue
+		}
+
+		txsToKeep = append(txsToKeep, tx)
+	}
+
+	return txsToKeep
+}
+
+func filterTransactions(txs []*data.FullTransaction, txsHashesToKeep map[string]struct{}) []*data.FullTransaction {
+	txsToKeep := make([]*data.FullTransaction, 0, len(txs))
+
+	for _, tx := range txs {
+		_, shouldKeep := txsHashesToKeep[tx.Hash]
+		if shouldKeep {
+			txsToKeep = append(txsToKeep, tx)
+		}
+	}
+
+	return txsToKeep
+}
+
+func deduplicateTransactions(txs []*data.FullTransaction) []*data.FullTransaction {
+	deduplicatedTxs := make([]*data.FullTransaction, 0, len(txs))
+	seenTxsHashes := make(map[string]struct{})
+
+	for _, tx := range txs {
+		_, alreadySeen := seenTxsHashes[tx.Hash]
+		if alreadySeen {
+			continue
+		}
+
+		deduplicatedTxs = append(deduplicatedTxs, tx)
+		seenTxsHashes[tx.Hash] = struct{}{}
+	}
+
+	return deduplicatedTxs
+}

--- a/server/provider/transactions_test.go
+++ b/server/provider/transactions_test.go
@@ -1,0 +1,54 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscardTransactions(t *testing.T) {
+	transactions := []*data.FullTransaction{
+		{Hash: "aaaa"},
+		{Hash: "bbbb"},
+		{Hash: "aabb"},
+		{Hash: "abba"},
+	}
+
+	txsHashesToDiscard := map[string]struct{}{"aabb": {}, "abba": {}}
+	result := discardTransactions(transactions, txsHashesToDiscard)
+	require.Len(t, result, 2)
+	require.Equal(t, "aaaa", result[0].Hash)
+	require.Equal(t, "bbbb", result[1].Hash)
+}
+
+func TestFilterTransactions(t *testing.T) {
+	transactions := []*data.FullTransaction{
+		{Hash: "aaaa"},
+		{Hash: "bbbb"},
+		{Hash: "aabb"},
+		{Hash: "abba"},
+	}
+
+	txsHashesToKeep := map[string]struct{}{"aabb": {}, "abba": {}}
+	result := filterTransactions(transactions, txsHashesToKeep)
+	require.Len(t, result, 2)
+	require.Equal(t, "aabb", result[0].Hash)
+	require.Equal(t, "abba", result[1].Hash)
+}
+
+func TestDeduplicateTransactions(t *testing.T) {
+	transactions := []*data.FullTransaction{
+		{Hash: "aaaa"},
+		{Hash: "bbbb"},
+		{Hash: "aabb"},
+		{Hash: "bbbb"},
+		{Hash: "aaaa"},
+	}
+
+	result := deduplicateTransactions(transactions)
+	require.Len(t, result, 3)
+	require.Equal(t, "aaaa", result[0].Hash)
+	require.Equal(t, "bbbb", result[1].Hash)
+	require.Equal(t, "aabb", result[2].Hash)
+}

--- a/version/constants.go
+++ b/version/constants.go
@@ -5,7 +5,7 @@ const (
 	RosettaVersion = "v1.4.12"
 
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.1.2"
+	RosettaMiddlewareVersion = "v0.1.3"
 
 	// NodeVersion is the canonical version of the node runtime
 	NodeVersion = "rc/2022-july"


### PR DESCRIPTION
Generally speaking, if a block `N` contains a **scheduled** miniblock with an invalid transaction `T`, this transaction will be added in the intrashard miniblock of type **InvalidBlock**, which is stored in the receipts unit - and provided by the Node API, as well.

Though, if, additionally, block `N` is the first shard block after an epoch change, the aforementioned miniblock (from receipts unit) isn't provided by the API (regarding this, further debugging is needed on Node's side).

**Issue (duplicated / misleading balance-changing operations)**

Rosetta sees the invalid transaction `T` in block `N` (in a **scheduled** miniblock) and acknowledges it's balance-changing operations (not knowing it is invalid). Then, Rosetta sees transaction `T` in block `N+1` once again, and it's current de-duplication logic fails: the balance-changing operations - only the transaction fee, this time - are acknowledge once again.

**Solution**

Rewrote handling of scheduled miniblocks, especially around invalid transactions. Use both **look-ahead** and **look-behind** strategies (that is, when block `N` is requested, inspect both `N-1` and `N+1`). **Look-ahead** is required to discriminate between successful scheduled transactions and invalid scheduled transactions (as previously mentioned, the presence, on the Node API, of the invalid miniblock from the receipts unit is not reliable at block `N`, at start of epoch). **Look-behind** is required to discriminate between "regular" invalid transactions and invalid transactions once scheduled in a previous block.

Furthermore, _observing not-final blocks_ isn't a CLI option anymore (due to the **look-ahead** strategy for scheduled transactions).

More tests are being added in https://github.com/ElrondNetwork/rosetta/pull/11.