### PR TITLE
Edge case: cross-shard scheduled miniblocks with construction state = final.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ Below, we build all the images (including for  _devnet_).
 ```
 cd $HOME/rosetta
 
-docker image build . -t elrond-rosetta:latest -f ./docker/Rosetta.dockerfile
-docker image build . -t elrond-rosetta-observer-devnet:latest -f ./docker/ObserverDevnet.dockerfile
-docker image build . -t elrond-rosetta-observer-mainnet:latest -f ./docker/ObserverMainnet.dockerfile
+docker image build --no-cache . -t elrond-rosetta:latest -f ./docker/Rosetta.dockerfile
+docker image build --no-cache . -t elrond-rosetta-observer-devnet:latest -f ./docker/ObserverDevnet.dockerfile
+docker image build --no-cache . -t elrond-rosetta-observer-mainnet:latest -f ./docker/ObserverMainnet.dockerfile
 ```
 
 ### Run rosetta

--- a/docker/ObserverDevnet.dockerfile
+++ b/docker/ObserverDevnet.dockerfile
@@ -13,6 +13,9 @@ RUN cp /go/pkg/mod/github.com/!elrond!network/arwen-wasm-vm@$(cat /go/elrond-go/
 # Enable DbLookupExtensions 
 RUN sed -i '/\[DbLookupExtensions\]/!b;n;c\\tEnabled = true' /go/elrond-config-devnet/config.toml
 
+# StartInEpochEnabled = false
+RUN sed -i 's/StartInEpochEnabled = true/StartInEpochEnabled = false/g' /go/elrond-config-devnet/config.toml
+
 # ===== SECOND STAGE ======
 FROM ubuntu:20.04
 

--- a/docker/ObserverDevnet.dockerfile
+++ b/docker/ObserverDevnet.dockerfile
@@ -1,8 +1,8 @@
 FROM golang:1.17.6 as builder
 
 # Clone repositories
-RUN git clone https://github.com/ElrondNetwork/elrond-config-devnet --branch=7f043791dc66c01f002579763d7417713f241ed8 --depth=1
-RUN git clone https://github.com/ElrondNetwork/elrond-go.git --branch=d51fa71ccc307b5ee3877ecd0920ee86ec8632e3 --depth=1
+RUN git clone https://github.com/ElrondNetwork/elrond-config-devnet --branch=rc-2022-july --depth=1
+RUN git clone https://github.com/ElrondNetwork/elrond-go.git --branch=rc/2022-july --depth=1
 
 # Build node
 WORKDIR /go/elrond-go/cmd/node

--- a/docker/ObserverMainnet.dockerfile
+++ b/docker/ObserverMainnet.dockerfile
@@ -13,6 +13,9 @@ RUN cp /go/pkg/mod/github.com/!elrond!network/arwen-wasm-vm@$(cat /go/elrond-go/
 # Enable DbLookupExtensions 
 RUN sed -i '/\[DbLookupExtensions\]/!b;n;c\\tEnabled = true' /go/elrond-config-mainnet/config.toml
 
+# StartInEpochEnabled = false
+RUN sed -i 's/StartInEpochEnabled = true/StartInEpochEnabled = false/g' /go/elrond-config-devnet/config.toml
+
 # ===== SECOND STAGE ======
 FROM ubuntu:20.04
 

--- a/docker/Rosetta.dockerfile
+++ b/docker/Rosetta.dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.18 as builder
 
 # Clone repositories
-RUN git clone https://github.com/ElrondNetwork/rosetta.git --branch=development-07-18 --depth=1
+RUN git clone https://github.com/ElrondNetwork/rosetta.git --branch=main --depth=1
 
 # Build
 WORKDIR /go/rosetta/cmd/rosetta

--- a/docker/Rosetta.dockerfile
+++ b/docker/Rosetta.dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.18 as builder
 
 # Clone repositories
-RUN git clone https://github.com/ElrondNetwork/rosetta.git --branch=main --depth=1
+RUN git clone https://github.com/ElrondNetwork/rosetta.git --branch=development-07-18 --depth=1
 
 # Build
 WORKDIR /go/rosetta/cmd/rosetta

--- a/server/provider/constants.go
+++ b/server/provider/constants.go
@@ -12,11 +12,3 @@ var genesisBlockNonce = 0
 // Defined in the scope of the Rosetta node:
 var requestTimeoutInSeconds = 60
 var nodeStatusCacheDuration = time.Duration(1 * time.Second)
-
-type MiniblockProcessingType string
-
-const (
-	Normal    MiniblockProcessingType = "Normal"
-	Scheduled MiniblockProcessingType = "Scheduled"
-	Processed MiniblockProcessingType = "Processed"
-)

--- a/server/provider/scheduledMiniblocks.go
+++ b/server/provider/scheduledMiniblocks.go
@@ -62,7 +62,10 @@ func removeProcessedMiniblocksOfBlock(block *data.Block) {
 
 func removeScheduledMiniblocks(block *data.Block) {
 	removeMiniblocksFromBlock(block, func(miniblock *data.MiniBlock) bool {
-		return miniblock.ProcessingType == string(Scheduled)
+		hasProcessingTypeScheduled := miniblock.ProcessingType == string(Scheduled)
+		hasConstructionStateNotFinal := miniblock.ConstructionState != dataBlock.Final.String()
+
+		return hasProcessingTypeScheduled && hasConstructionStateNotFinal
 	})
 }
 
@@ -96,7 +99,10 @@ func findScheduledTransactionsHashes(block *data.Block) map[string]struct{} {
 	invalidTxs := make(map[string]struct{})
 
 	for _, miniblock := range block.MiniBlocks {
-		if miniblock.ProcessingType == string(Scheduled) {
+		hasProcessingTypeScheduled := miniblock.ProcessingType == string(Scheduled)
+		hasConstructionStateNotFinal := miniblock.ConstructionState != dataBlock.Final.String()
+
+		if hasProcessingTypeScheduled && hasConstructionStateNotFinal {
 			for _, tx := range miniblock.Transactions {
 				invalidTxs[tx.Hash] = struct{}{}
 			}

--- a/server/provider/scheduledMiniblocks.go
+++ b/server/provider/scheduledMiniblocks.go
@@ -25,7 +25,16 @@ func (provider *networkProvider) simplifyBlockWithScheduledTransactions(block *d
 	return nil
 }
 
-// TODO after review: Move below (diff is easier to follow as it is now)
+func hasOnlyNormalMiniblocks(block *data.Block) bool {
+	for _, miniblock := range block.MiniBlocks {
+		if miniblock.ProcessingType != dataBlock.Normal.String() {
+			return false
+		}
+	}
+
+	return true
+}
+
 func doSimplifyBlockWithScheduledTransactions(previousBlock *data.Block, block *data.Block, nextBlock *data.Block) {
 	// Discard "processed" miniblocks in block N, since they already produced effects in N-1
 	removeProcessedMiniblocksOfBlock(block)
@@ -50,16 +59,6 @@ func doSimplifyBlockWithScheduledTransactions(previousBlock *data.Block, block *
 	// Discard "scheduled" miniblocks of N, since we've already brought the "processed" ones from N+1,
 	// and also handled the "invalid" ones.
 	removeScheduledMiniblocks(block)
-}
-
-func hasOnlyNormalMiniblocks(block *data.Block) bool {
-	for _, miniblock := range block.MiniBlocks {
-		if miniblock.ProcessingType != dataBlock.Normal.String() {
-			return false
-		}
-	}
-
-	return true
 }
 
 func removeProcessedMiniblocksOfBlock(block *data.Block) {

--- a/server/provider/scheduledMiniblocks.go
+++ b/server/provider/scheduledMiniblocks.go
@@ -72,8 +72,8 @@ func removeScheduledMiniblocks(block *data.Block) {
 	removeMiniblocksFromBlock(block, func(miniblock *data.MiniBlock) bool {
 		hasProcessingTypeScheduled := miniblock.ProcessingType == dataBlock.Scheduled.String()
 		hasConstructionStateNotFinal := miniblock.ConstructionState != dataBlock.Final.String()
-
-		return hasProcessingTypeScheduled && hasConstructionStateNotFinal
+		shouldRemove := hasProcessingTypeScheduled && hasConstructionStateNotFinal
+		return shouldRemove
 	})
 }
 
@@ -104,20 +104,21 @@ func gatherInvalidTransactions(previousBlock *data.Block, block *data.Block, nex
 }
 
 func findScheduledTransactionsHashes(block *data.Block) map[string]struct{} {
-	invalidTxs := make(map[string]struct{})
+	txs := make(map[string]struct{})
 
 	for _, miniblock := range block.MiniBlocks {
 		hasProcessingTypeScheduled := miniblock.ProcessingType == dataBlock.Scheduled.String()
 		hasConstructionStateNotFinal := miniblock.ConstructionState != dataBlock.Final.String()
+		shouldAccumulateTxs := hasProcessingTypeScheduled && hasConstructionStateNotFinal
 
-		if hasProcessingTypeScheduled && hasConstructionStateNotFinal {
+		if shouldAccumulateTxs {
 			for _, tx := range miniblock.Transactions {
-				invalidTxs[tx.Hash] = struct{}{}
+				txs[tx.Hash] = struct{}{}
 			}
 		}
 	}
 
-	return invalidTxs
+	return txs
 }
 
 func findProcessedMiniblocks(block *data.Block) []*data.MiniBlock {

--- a/version/constants.go
+++ b/version/constants.go
@@ -5,7 +5,7 @@ const (
 	RosettaVersion = "v1.4.12"
 
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.1.3"
+	RosettaMiddlewareVersion = "v0.1.4"
 
 	// NodeVersion is the canonical version of the node runtime
 	NodeVersion = "rc/2022-july"


### PR DESCRIPTION
 - Handle edge case: cross-shard scheduled miniblocks with `construction state = final`.
 - Added an extra condition to ignore empty (and artificial) invalid miniblocks (does not affect flow)
 - Adjust docker images to set `StartInEpoch = false`
 - Update readme (e.g. on how to avoid Docker caching when building images)