### PR TITLE
Define errFactory. Propagate error info (e.g. for GET account).

### DIFF
--- a/server/factory/controllers.go
+++ b/server/factory/controllers.go
@@ -3,7 +3,6 @@ package factory
 import (
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/rosetta/server/services"
-	"github.com/ElrondNetwork/rosetta/server/services/offline"
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -27,7 +26,7 @@ func createOfflineControllers(networkProvider services.NetworkProvider) ([]serve
 		return nil, err
 	}
 
-	offlineService := offline.NewOfflineService()
+	offlineService := services.NewOfflineService()
 
 	networkService := services.NewNetworkService(networkProvider)
 	networkController := server.NewNetworkAPIController(networkService, asserter)

--- a/server/provider/errors.go
+++ b/server/provider/errors.go
@@ -37,7 +37,7 @@ func convertStructuredApiErrToFlatErr(apiErr error) error {
 		return apiErr
 	}
 
-	flatErrString := fmt.Sprintf("%s; %s", structuredApiErr.Error, structuredApiErr.Code)
+	flatErrString := fmt.Sprintf("%s: %s", structuredApiErr.Error, structuredApiErr.Code)
 	flatErr := errors.New(flatErrString)
 	return flatErr
 }

--- a/server/provider/errors_test.go
+++ b/server/provider/errors_test.go
@@ -1,0 +1,16 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertStructuredApiErrToFlatErr(t *testing.T) {
+	err := convertStructuredApiErrToFlatErr(errors.New("{\"data\":null,\"error\":\"too many requests\",\"code\":\"system_busy\"}"))
+	require.Equal(t, errors.New("too many requests; system_busy"), err)
+
+	err = convertStructuredApiErrToFlatErr(errors.New("this is not a structured error"))
+	require.Equal(t, errors.New("this is not a structured error"), err)
+}

--- a/server/provider/errors_test.go
+++ b/server/provider/errors_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestConvertStructuredApiErrToFlatErr(t *testing.T) {
 	err := convertStructuredApiErrToFlatErr(errors.New("{\"data\":null,\"error\":\"too many requests\",\"code\":\"system_busy\"}"))
-	require.Equal(t, errors.New("too many requests; system_busy"), err)
+	require.Equal(t, errors.New("too many requests: system_busy"), err)
 
 	err = convertStructuredApiErrToFlatErr(errors.New("this is not a structured error"))
 	require.Equal(t, errors.New("this is not a structured error"), err)

--- a/server/services/accountService_test.go
+++ b/server/services/accountService_test.go
@@ -19,11 +19,11 @@ func TestAccountService_AccountBalance(t *testing.T) {
 
 	// With bad input address
 	_, err := getAccount(service, "")
-	require.Equal(t, ErrInvalidAccountAddress, err)
+	require.Equal(t, ErrInvalidAccountAddress, errCode(err.Code))
 
 	// When account does not exist
 	response, err := getAccount(service, testscommon.TestAddressAlice)
-	require.Equal(t, err.Code, ErrUnableToGetAccount.Code)
+	require.Equal(t, ErrUnableToGetAccount, errCode(err.Code))
 	require.Nil(t, response)
 
 	// When account exists

--- a/server/services/blockService_test.go
+++ b/server/services/blockService_test.go
@@ -109,7 +109,7 @@ func TestBlockService_BlockByIndex(t *testing.T) {
 	}
 
 	_, err := getBlockByIndex(service, 6)
-	require.Equal(t, ErrUnableToGetBlock.Code, err.Code)
+	require.Equal(t, ErrUnableToGetBlock, errCode(err.Code))
 
 	blockResponse, err := getBlockByIndex(service, 7)
 	require.Nil(t, err)

--- a/server/services/errors.go
+++ b/server/services/errors.go
@@ -31,10 +31,9 @@ const (
 )
 
 type errPrototype struct {
-	code        errCode
-	message     string
-	retriable   bool
-	description string
+	code      errCode
+	message   string
+	retriable bool
 }
 
 type errFactory struct {
@@ -163,10 +162,9 @@ func (factory *errFactory) getPossibleErrors() []*types.Error {
 
 	for _, prototype := range factory.prototypes {
 		possibleErrors = append(possibleErrors, &types.Error{
-			Code:        int32(prototype.code),
-			Message:     prototype.message,
-			Retriable:   prototype.retriable,
-			Description: &prototype.description,
+			Code:      int32(prototype.code),
+			Message:   prototype.message,
+			Retriable: prototype.retriable,
 		})
 	}
 
@@ -186,10 +184,9 @@ func (factory *errFactory) newErr(code errCode) *types.Error {
 	prototype := factory.getPrototypeByCode(code)
 
 	return &types.Error{
-		Code:        int32(code),
-		Message:     prototype.message,
-		Retriable:   prototype.retriable,
-		Description: &prototype.description,
+		Code:      int32(code),
+		Message:   prototype.message,
+		Retriable: prototype.retriable,
 	}
 }
 

--- a/server/services/errors.go
+++ b/server/services/errors.go
@@ -173,6 +173,15 @@ func (factory *errFactory) getPossibleErrors() []*types.Error {
 	return possibleErrors
 }
 
+func (factory *errFactory) newErrWithOriginal(code errCode, originalError error) *types.Error {
+	err := factory.newErr(code)
+	err.Details = map[string]interface{}{
+		"originalError": originalError.Error(),
+	}
+
+	return err
+}
+
 func (factory *errFactory) newErr(code errCode) *types.Error {
 	prototype := factory.getPrototypeByCode(code)
 
@@ -182,15 +191,6 @@ func (factory *errFactory) newErr(code errCode) *types.Error {
 		Retriable:   prototype.retriable,
 		Description: &prototype.description,
 	}
-}
-
-func (factory *errFactory) newErrWithOriginal(code errCode, originalError error) *types.Error {
-	err := factory.newErr(code)
-	err.Details = map[string]interface{}{
-		"originalError": originalError.Error(),
-	}
-
-	return err
 }
 
 func (factory *errFactory) getPrototypeByCode(code errCode) errPrototype {

--- a/server/services/errors.go
+++ b/server/services/errors.go
@@ -6,167 +6,200 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
-// TODO: find a better way to assign error codes, perhaps using module init(), and iterate over Errors array?
-var (
-	ErrUnableToGetChainID = &types.Error{
-		Code:      0,
-		Message:   "unable to get chain ID",
-		Retriable: true,
-	}
+type errCode int32
 
-	ErrUnableToGetAccount = &types.Error{
-		Code:      2,
-		Message:   "unable to get account",
-		Retriable: true,
-	}
-
-	ErrInvalidAccountAddress = &types.Error{
-		Code:      3,
-		Message:   "invalid account address",
-		Retriable: false,
-	}
-
-	ErrUnableToGetBlock = &types.Error{
-		Code:      4,
-		Message:   "unable to get block",
-		Retriable: true,
-	}
-
-	ErrNotImplemented = &types.Error{
-		Code:      5,
-		Message:   "operation not implemented",
-		Retriable: false,
-	}
-
-	ErrUnableToSubmitTransaction = &types.Error{
-		Code:      6,
-		Message:   "unable to submit transaction",
-		Retriable: false,
-	}
-
-	ErrMalformedValue = &types.Error{
-		Code:      7,
-		Message:   "malformed value",
-		Retriable: false,
-	}
-
-	ErrUnableToGetNodeStatus = &types.Error{
-		Code:      8,
-		Message:   "unable to get node status",
-		Retriable: true,
-	}
-
-	ErrUnableToGetClientVersion = &types.Error{
-		Code:      9,
-		Message:   "unable to get client version",
-		Retriable: true,
-	}
-
-	ErrMustQueryByIndexOrByHash = &types.Error{
-		Code:      10,
-		Message:   "must query block by index or by hash",
-		Retriable: false,
-	}
-
-	ErrConstructionCheck = &types.Error{
-		Code:      11,
-		Message:   "operation construction check error",
-		Retriable: false,
-	}
-
-	ErrUnableToGetNetworkConfig = &types.Error{
-		Code:      12,
-		Message:   "unable to get network config",
-		Retriable: true,
-	}
-
-	ErrInvalidInputParam = &types.Error{
-		Code:      13,
-		Message:   "Invalid input param: ",
-		Retriable: false,
-	}
-
-	ErrUnsupportedCurveType = &types.Error{
-		Code:      14,
-		Message:   "unsupported curve type",
-		Retriable: false,
-	}
-
-	ErrInsufficientGasLimit = &types.Error{
-		Code:      15,
-		Message:   "insufficient gas limit",
-		Retriable: false,
-	}
-
-	ErrGasPriceTooLow = &types.Error{
-		Code:      16,
-		Message:   "gas price is to low",
-		Retriable: false,
-	}
-	ErrTransactionIsNotInPool = &types.Error{
-		Code:      17,
-		Message:   "transaction is not in pool",
-		Retriable: false,
-	}
-
-	ErrCannotParsePoolTransaction = &types.Error{
-		Code:      18,
-		Message:   "cannot parse pool transaction",
-		Retriable: false,
-	}
-
-	ErrOfflineMode = &types.Error{
-		Code:      19,
-		Message:   "rosetta server is in offline mode",
-		Retriable: false,
-	}
-
-	ErrUnableToGetGenesisBlock = &types.Error{
-		Code:      20,
-		Message:   "unable to get genesis block",
-		Retriable: true,
-	}
-
-	Errors = []*types.Error{
-		ErrUnableToGetChainID,
-		ErrUnableToGetAccount,
-		ErrInvalidAccountAddress,
-		ErrUnableToGetBlock,
-		ErrNotImplemented,
-		ErrUnableToSubmitTransaction,
-		ErrMalformedValue,
-		ErrUnableToGetNodeStatus,
-		ErrUnableToGetClientVersion,
-		ErrMustQueryByIndexOrByHash,
-		ErrConstructionCheck,
-		ErrUnableToGetNetworkConfig,
-		ErrUnsupportedCurveType,
-		ErrInsufficientGasLimit,
-		ErrGasPriceTooLow,
-		ErrTransactionIsNotInPool,
-		ErrCannotParsePoolTransaction,
-		ErrInvalidInputParam,
-		ErrOfflineMode,
-		ErrUnableToGetGenesisBlock,
-	}
+const (
+	ErrUnknown errCode = iota + 1
+	ErrUnableToGetAccount
+	ErrInvalidAccountAddress
+	ErrUnableToGetBlock
+	ErrNotImplemented
+	ErrUnableToSubmitTransaction
+	ErrMalformedValue
+	ErrUnableToGetNodeStatus
+	ErrMustQueryByIndexOrByHash
+	ErrConstructionCheck
+	ErrUnableToGetNetworkConfig
+	ErrUnsupportedCurveType
+	ErrInsufficientGasLimit
+	ErrGasPriceTooLow
+	ErrTransactionIsNotInPool
+	ErrCannotParsePoolTransaction
+	ErrInvalidInputParam
+	ErrOfflineMode
+	ErrUnableToGetGenesisBlock
 )
 
-// wrapErr adds details to the types.Error provided. We use a function
-// to do this so that we don't accidentally overwrite the standard
-// errors.
-func wrapErr(rErr *types.Error, err error) *types.Error {
-	newErr := &types.Error{
-		Code:      rErr.Code,
-		Message:   rErr.Message,
-		Retriable: rErr.Retriable,
+type errPrototype struct {
+	code        errCode
+	message     string
+	retriable   bool
+	description string
+}
+
+type errFactory struct {
+	prototypes    []errPrototype
+	prototypesMap map[errCode]errPrototype
+}
+
+func newErrFactory() *errFactory {
+	prototypes, prototypesMap := createErrPrototypes()
+	return &errFactory{
+		prototypes:    prototypes,
+		prototypesMap: prototypesMap,
 	}
-	if err != nil {
-		newErr.Details = map[string]interface{}{
-			"context": err.Error(),
-		}
+}
+
+func createErrPrototypes() ([]errPrototype, map[errCode]errPrototype) {
+	prototypes := []errPrototype{
+		{
+			code:      ErrUnknown,
+			message:   "unknown error",
+			retriable: false,
+		},
+		{
+			code:      ErrUnableToGetAccount,
+			message:   "unable to get account",
+			retriable: true,
+		},
+		{
+			code:      ErrInvalidAccountAddress,
+			message:   "invalid account address",
+			retriable: false,
+		},
+		{
+			code:      ErrUnableToGetBlock,
+			message:   "unable to get block",
+			retriable: true,
+		},
+		{
+			code:      ErrNotImplemented,
+			message:   "operation not implemented",
+			retriable: false,
+		},
+		{
+			code:      ErrUnableToSubmitTransaction,
+			message:   "unable to submit transaction",
+			retriable: true,
+		},
+		{
+			code:      ErrMalformedValue,
+			message:   "malformed value",
+			retriable: false,
+		},
+		{
+			code:      ErrUnableToGetNodeStatus,
+			message:   "unable to get node status",
+			retriable: true,
+		},
+		{
+			code:      ErrMustQueryByIndexOrByHash,
+			message:   "must query block by index or by hash",
+			retriable: false,
+		},
+		{
+			code:      ErrConstructionCheck,
+			message:   "operation construction check error",
+			retriable: false,
+		},
+		{
+			code:      ErrUnableToGetNetworkConfig,
+			message:   "unable to get network config",
+			retriable: true,
+		},
+		{
+			code:      ErrInvalidInputParam,
+			message:   "Invalid input param: ",
+			retriable: false,
+		},
+		{
+			code:      ErrUnsupportedCurveType,
+			message:   "unsupported curve type",
+			retriable: false,
+		},
+		{
+			code:      ErrInsufficientGasLimit,
+			message:   "insufficient gas limit",
+			retriable: false,
+		},
+		{
+			code:      ErrGasPriceTooLow,
+			message:   "gas price is to low",
+			retriable: false,
+		},
+		{
+			code:      ErrTransactionIsNotInPool,
+			message:   "transaction is not in pool",
+			retriable: true,
+		},
+		{
+			code:      ErrCannotParsePoolTransaction,
+			message:   "cannot parse pool transaction",
+			retriable: false,
+		},
+		{
+			code:      ErrOfflineMode,
+			message:   "rosetta server is in offline mode",
+			retriable: false,
+		},
+		{
+			code:      ErrUnableToGetGenesisBlock,
+			message:   "unable to get genesis block",
+			retriable: true,
+		},
 	}
 
-	return newErr
+	prototypesMap := make(map[errCode]errPrototype)
+
+	for _, prototype := range prototypes {
+		prototypesMap[prototype.code] = prototype
+	}
+
+	return prototypes, prototypesMap
+}
+
+func (factory *errFactory) getPossibleErrors() []*types.Error {
+	possibleErrors := make([]*types.Error, 0, len(factory.prototypes))
+
+	for _, prototype := range factory.prototypes {
+		possibleErrors = append(possibleErrors, &types.Error{
+			Code:        int32(prototype.code),
+			Message:     prototype.message,
+			Retriable:   prototype.retriable,
+			Description: &prototype.description,
+		})
+	}
+
+	return possibleErrors
+}
+
+func (factory *errFactory) newErr(code errCode) *types.Error {
+	prototype := factory.getPrototypeByCode(code)
+
+	return &types.Error{
+		Code:        int32(code),
+		Message:     prototype.message,
+		Retriable:   prototype.retriable,
+		Description: &prototype.description,
+	}
+}
+
+func (factory *errFactory) newErrWithOriginal(code errCode, originalError error) *types.Error {
+	err := factory.newErr(code)
+	err.Details = map[string]interface{}{
+		"originalError": originalError.Error(),
+	}
+
+	return err
+}
+
+func (factory *errFactory) getPrototypeByCode(code errCode) errPrototype {
+	prototype, ok := factory.prototypesMap[code]
+	if ok {
+		return prototype
+	}
+
+	return factory.prototypesMap[ErrUnknown]
 }
 
 var errEventNotFound = errors.New("transaction event not found")

--- a/server/services/mempoolService_test.go
+++ b/server/services/mempoolService_test.go
@@ -17,7 +17,7 @@ func TestMempoolService_MempoolTransactionCannotFindTxInPool(t *testing.T) {
 	service := NewMempoolService(networkProvider)
 
 	txResponse, err := getMempoolTransactionByHash(service, "aaaa")
-	require.Equal(t, ErrTransactionIsNotInPool.Code, err.Code)
+	require.Equal(t, ErrTransactionIsNotInPool, errCode(err.Code))
 	require.Nil(t, txResponse)
 }
 

--- a/server/services/networkService_test.go
+++ b/server/services/networkService_test.go
@@ -39,7 +39,7 @@ func TestNetworkService_NetworkOptions(t *testing.T) {
 		Allow: &types.Allow{
 			OperationStatuses: supportedOperationStatuses,
 			OperationTypes:    SupportedOperationTypes,
-			Errors:            Errors,
+			Errors:            newErrFactory().getPossibleErrors(),
 		},
 	}, networkOptions)
 }

--- a/server/services/offline_services.go
+++ b/server/services/offline_services.go
@@ -1,13 +1,14 @@
-package offline
+package services
 
 import (
 	"context"
 
-	"github.com/ElrondNetwork/rosetta/server/services"
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
-type offlineService struct{}
+type offlineService struct {
+	errFactory *errFactory
+}
 
 // NewOfflineService will create a new instance of offlineService
 func NewOfflineService() *offlineService {
@@ -15,68 +16,68 @@ func NewOfflineService() *offlineService {
 }
 
 // AccountBalance implements the /account/balance endpoint.
-func (os *offlineService) AccountBalance(
+func (service *offlineService) AccountBalance(
 	_ context.Context,
 	_ *types.AccountBalanceRequest,
 ) (*types.AccountBalanceResponse, *types.Error) {
-	return nil, services.ErrOfflineMode
+	return nil, service.errFactory.newErr(ErrOfflineMode)
 }
 
 // AccountCoins implements the /account/coins endpoint.
-func (os *offlineService) AccountCoins(_ context.Context, _ *types.AccountCoinsRequest) (*types.AccountCoinsResponse, *types.Error) {
-	return nil, services.ErrOfflineMode
+func (service *offlineService) AccountCoins(_ context.Context, _ *types.AccountCoinsRequest) (*types.AccountCoinsResponse, *types.Error) {
+	return nil, service.errFactory.newErr(ErrOfflineMode)
 }
 
 // Block implements the /block endpoint.
-func (os *offlineService) Block(
+func (service *offlineService) Block(
 	_ context.Context,
 	_ *types.BlockRequest,
 ) (*types.BlockResponse, *types.Error) {
-	return nil, services.ErrOfflineMode
+	return nil, service.errFactory.newErr(ErrOfflineMode)
 }
 
 // BlockTransaction - not implemented
 // We dont need this method because all transactions are returned by method Block
-func (os *offlineService) BlockTransaction(
+func (service *offlineService) BlockTransaction(
 	_ context.Context,
 	_ *types.BlockTransactionRequest,
 ) (*types.BlockTransactionResponse, *types.Error) {
-	return nil, services.ErrOfflineMode
+	return nil, service.errFactory.newErr(ErrOfflineMode)
 }
 
 // Mempool is not implemented yet
-func (os *offlineService) Mempool(context.Context, *types.NetworkRequest) (*types.MempoolResponse, *types.Error) {
-	return nil, services.ErrOfflineMode
+func (service *offlineService) Mempool(context.Context, *types.NetworkRequest) (*types.MempoolResponse, *types.Error) {
+	return nil, service.errFactory.newErr(ErrOfflineMode)
 }
 
 // MempoolTransaction will return operations for a transaction that is in pool
-func (os *offlineService) MempoolTransaction(
+func (service *offlineService) MempoolTransaction(
 	_ context.Context,
 	_ *types.MempoolTransactionRequest,
 ) (*types.MempoolTransactionResponse, *types.Error) {
-	return nil, services.ErrOfflineMode
+	return nil, service.errFactory.newErr(ErrOfflineMode)
 }
 
 // NetworkStatus implements the /network/status endpoint.
-func (os *offlineService) NetworkStatus(
+func (service *offlineService) NetworkStatus(
 	_ context.Context,
 	_ *types.NetworkRequest,
 ) (*types.NetworkStatusResponse, *types.Error) {
-	return nil, services.ErrOfflineMode
+	return nil, service.errFactory.newErr(ErrOfflineMode)
 }
 
 // NetworkOptions implements the /network/options endpoint.
-func (os *offlineService) NetworkOptions(
+func (service *offlineService) NetworkOptions(
 	_ context.Context,
 	_ *types.NetworkRequest,
 ) (*types.NetworkOptionsResponse, *types.Error) {
-	return nil, services.ErrOfflineMode
+	return nil, service.errFactory.newErr(ErrOfflineMode)
 }
 
 // NetworkList implements the /network/list endpoint
-func (os *offlineService) NetworkList(
+func (service *offlineService) NetworkList(
 	_ context.Context,
 	_ *types.MetadataRequest,
 ) (*types.NetworkListResponse, *types.Error) {
-	return nil, services.ErrOfflineMode
+	return nil, service.errFactory.newErr(ErrOfflineMode)
 }

--- a/version/constants.go
+++ b/version/constants.go
@@ -5,7 +5,7 @@ const (
 	RosettaVersion = "v1.4.12"
 
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.1.4"
+	RosettaMiddlewareVersion = "v0.1.5"
 
 	// NodeVersion is the canonical version of the node runtime
 	NodeVersion = "rc/2022-july"


### PR DESCRIPTION
 - Propagate information about original errors (see `error.details.originalError`) in the context of `GET account/balance`.
 - Error definitions have been refactored (added an `errFactory`).
 - Some error codes have changed, but this should not be a major version at this point (wrt. semver guidelines) - since `v1.0.0` is not released yet.
 - More tests will be added in https://github.com/ElrondNetwork/rosetta/pull/11.