### PR TITLE
Hotfix on handling scheduled transactions

### DIFF
--- a/server/provider/constants.go
+++ b/server/provider/constants.go
@@ -1,7 +1,5 @@
 package provider
 
-import "time"
-
 // Defined by the Network:
 var hasherType = "blake2b"
 var marshalizerForHashingType = "gogo protobuf"
@@ -11,4 +9,3 @@ var genesisBlockNonce = 0
 
 // Defined in the scope of the Rosetta node:
 var requestTimeoutInSeconds = 60
-var nodeStatusCacheDuration = time.Duration(1 * time.Second)

--- a/server/provider/networkProvider.go
+++ b/server/provider/networkProvider.go
@@ -288,7 +288,8 @@ func (provider *networkProvider) getLatestBlockNonce() (uint64, error) {
 		return 0, err
 	}
 
-	return nodeStatus.HighestFinalNonce, nil
+	// In the context of scheduled transactions, make sure the N+1 block is final, as well.
+	return nodeStatus.HighestFinalNonce - 1, nil
 }
 
 func (provider *networkProvider) getNodeStatus() (*resources.NodeStatus, error) {

--- a/server/provider/networkProvider.go
+++ b/server/provider/networkProvider.go
@@ -29,7 +29,6 @@ var (
 	notApplicableConfigurationFilePath   = "not applicable"
 	notApplicableFullHistoryNodesMessage = "not applicable"
 
-	urlPathGetNetworkConfig   = "/network/config"
 	urlPathGetNodeStatus      = "/node/status"
 	urlPathGetGenesisBalances = "/network/genesis-balances"
 	urlPathGetAccount         = "/address/%s"
@@ -331,7 +330,11 @@ func (provider *networkProvider) GetBlockByNonce(nonce uint64) (*data.Block, err
 		return nil, err
 	}
 
-	provider.simplifyBlockWithScheduledTransactions(block)
+	err = provider.simplifyBlockWithScheduledTransactions(block)
+	if err != nil {
+		return nil, err
+	}
+
 	return block, nil
 }
 
@@ -364,7 +367,11 @@ func (provider *networkProvider) GetBlockByHash(hash string) (*data.Block, error
 		return nil, err
 	}
 
-	provider.simplifyBlockWithScheduledTransactions(block)
+	err = provider.simplifyBlockWithScheduledTransactions(block)
+	if err != nil {
+		return nil, err
+	}
+
 	return block, nil
 }
 

--- a/version/constants.go
+++ b/version/constants.go
@@ -5,7 +5,7 @@ const (
 	RosettaVersion = "v1.4.12"
 
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.1.5"
+	RosettaMiddlewareVersion = "v0.1.6"
 
 	// NodeVersion is the canonical version of the node runtime
 	NodeVersion = "rc/2022-july"


### PR DESCRIPTION
 - Handle (check) errors. Previously, the error returned by `simplifyBlockWithScheduledTransactions` wasn't checked. This resulted in the block not being "simplified", but still returned to the caller (bug). As a consequence, when the _tip_ of the chain was a block N with processed (previously scheduled) miniblocks, and the request to block N+1 failed (see below), then the "not-simplified" N would re-emit transactions previously emitted in N-1 (as scheduled).
 - Example of failed GET `block/by-nonce` requests (node API): `err = key ... not found in BlockHeaders `
 - In the context of scheduled transactions, make sure the `N+1` block is final, as well.

The error was detected when performing a slow-paced [import-db](https://docs.elrond.com/validators/import-db/#docsNav) operation on epochs 717-718 of shard 2 (mainnet), while running the rosetta-cli checker. The issue manifested at blocks 10337348 - 10337349 (reproducible 100% before the fix, not reproducible after the fix).