### PR TITLE
Print version when starting

### DIFF
--- a/cmd/rosetta/main.go
+++ b/cmd/rosetta/main.go
@@ -46,7 +46,7 @@ func startRosetta(ctx *cli.Context) error {
 		return err
 	}
 
-	log.Info("Starting Rosetta...")
+	log.Info("Starting Rosetta...", "middleware", version.RosettaMiddlewareVersion, "specification", version.RosettaVersion, "node", version.NodeVersion)
 
 	networkProvider, err := provider.NewNetworkProvider(provider.ArgsNewNetworkProvider{
 		IsOffline:                   cliFlags.offline,


### PR DESCRIPTION
Example:

```
INFO [time] Starting Rosetta... middleware = v0.1.6 specification = v1.4.12 node = rc/2022-july
```