### PR TITLE
Always perform simplifyBlockWithScheduledTransactions().

### DIFF
--- a/server/provider/scheduledMiniblocks.go
+++ b/server/provider/scheduledMiniblocks.go
@@ -6,10 +6,6 @@ import (
 )
 
 func (provider *networkProvider) simplifyBlockWithScheduledTransactions(block *data.Block) error {
-	if hasOnlyNormalMiniblocks(block) {
-		return nil
-	}
-
 	previousBlock, err := provider.doGetBlockByNonce(block.Nonce - 1)
 	if err != nil {
 		return err

--- a/version/constants.go
+++ b/version/constants.go
@@ -5,7 +5,7 @@ const (
 	RosettaVersion = "v1.4.12"
 
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.1.7"
+	RosettaMiddlewareVersion = "v0.1.8"
 
 	// NodeVersion is the canonical version of the node runtime
 	NodeVersion = "rc/2022-july"


### PR DESCRIPTION
Always perform `simplifyBlockWithScheduledTransactions()`.

Previously, this step was skipped for blocks that only contained `normal` miniblocks, which lead to an incorrect handling of invalid scheduled transactions (that may be originating in the previous block).