### PR TITLE
Adjust logging

### DIFF
--- a/cmd/rosetta/main.go
+++ b/cmd/rosetta/main.go
@@ -107,8 +107,7 @@ func createHttpServer(port int, routers ...server.Router) (*http.Server, error) 
 		routers...,
 	)
 
-	loggedRouter := server.LoggerMiddleware(router)
-	corsRouter := server.CorsMiddleware(loggedRouter)
+	corsRouter := server.CorsMiddleware(router)
 
 	httpServer := &http.Server{
 		Addr:    fmt.Sprintf(":%d", port),

--- a/docker/ObserverDevnet.dockerfile
+++ b/docker/ObserverDevnet.dockerfile
@@ -25,4 +25,4 @@ COPY --from=builder "/lib/libwasmer_linux_amd64.so" "/lib/libwasmer_linux_amd64.
 
 EXPOSE 8080
 WORKDIR /elrond
-ENTRYPOINT ["/elrond/node", "--log-save", "--log-level=*:INFO,core/dblookupext:WARN", "--log-logger-name", "--rest-api-interface=0.0.0.0:8080", "--working-directory=/data"]
+ENTRYPOINT ["/elrond/node", "--log-save", "--log-level=*:DEBUG", "--log-logger-name", "--rest-api-interface=0.0.0.0:8080", "--working-directory=/data"]

--- a/docker/ObserverMainnet.dockerfile
+++ b/docker/ObserverMainnet.dockerfile
@@ -25,4 +25,4 @@ COPY --from=builder "/lib/libwasmer_linux_amd64.so" "/lib/libwasmer_linux_amd64.
 
 EXPOSE 8080
 WORKDIR /elrond
-ENTRYPOINT ["/elrond/node", "--log-save", "--log-level=*:INFO,core/dblookupext:WARN", "--log-logger-name", "--rest-api-interface=0.0.0.0:8080", "--working-directory=/data"]
+ENTRYPOINT ["/elrond/node", "--log-save", "--log-level=*:DEBUG", "--log-logger-name", "--rest-api-interface=0.0.0.0:8080", "--working-directory=/data"]

--- a/version/constants.go
+++ b/version/constants.go
@@ -5,7 +5,7 @@ const (
 	RosettaVersion = "v1.4.12"
 
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.1.8"
+	RosettaMiddlewareVersion = "v0.1.9"
 
 	// NodeVersion is the canonical version of the node runtime
 	NodeVersion = "rc/2022-july"


### PR DESCRIPTION
 - Do not log the API calls summary anymore
 - Increase the log level of the observer to `*:DEBUG` (this leads to ~5-6 GB of logs per week, on mainnet).