### PR TITLE
Historical lookup - part 2

### DIFF
--- a/checks/devnet/devnet-data-historical.json
+++ b/checks/devnet/devnet-data-historical.json
@@ -37,9 +37,9 @@
     "initial_balance_fetch_disabled": false,
     "historical_balance_disabled": false,
     "end_conditions": {
-      "duration": 28800,
       "reconciliation_coverage": {
-        "coverage": 1
+        "coverage": 1,
+        "from_tip": true
       }
     }
   }

--- a/checks/mainnet/README.md
+++ b/checks/mainnet/README.md
@@ -23,6 +23,6 @@ rosetta-cli check:data --configuration-file mainnet-data-start-after-${AFTER_BLO
 Or, using historical balances:
 
 ```
-rosetta-cli check:data --configuration-file mainnet-data-start-historical.json \
+rosetta-cli check:data --configuration-file mainnet-data-historical.json \
 --online-url=${ROSETTA_ONLINE} --data-dir=mainnet-${AFTER_BLOCK}-historical
 ```

--- a/checks/mainnet/mainnet-data-historical.json
+++ b/checks/mainnet/mainnet-data-historical.json
@@ -37,9 +37,9 @@
     "initial_balance_fetch_disabled": false,
     "historical_balance_disabled": false,
     "end_conditions": {
-      "duration": 28800,
       "reconciliation_coverage": {
-        "coverage": 1
+        "coverage": 1,
+        "from_tip": true
       }
     }
   }

--- a/server/provider/nodeStatus.go
+++ b/server/provider/nodeStatus.go
@@ -57,7 +57,8 @@ func (provider *networkProvider) getLatestBlockNonce() (uint64, error) {
 }
 
 func getLatestNonceGivenHighestFinalNonce(highestFinalNonce uint64) uint64 {
-	return highestFinalNonce - 1
+	// Account for rollback-related edge cases while node is syncing (in conjunction with scheduled miniblocks).
+	return highestFinalNonce - 2
 }
 
 func (provider *networkProvider) getOldestNonceWithHistoricalStateGivenNodeStatus(status *resources.NodeStatus) uint64 {

--- a/server/provider/nodeStatus_test.go
+++ b/server/provider/nodeStatus_test.go
@@ -36,14 +36,14 @@ func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
 
 	observerFacade.GetBlockByNonceCalled = func(shardID uint32, nonce uint64, options common.BlockQueryOptions) (*data.BlockApiResponse, error) {
 		// The one before "HighestFinalNonce"
-		if nonce == 4 {
+		if nonce == 3 {
 			return &data.BlockApiResponse{
 				Data: data.BlockApiResponsePayload{
 					Block: data.Block{
-						Nonce:         4,
-						Hash:          "0004",
-						PrevBlockHash: "0003",
-						Timestamp:     4,
+						Nonce:         3,
+						Hash:          "0003",
+						PrevBlockHash: "0002",
+						Timestamp:     3,
 					},
 				},
 			}, nil
@@ -63,14 +63,14 @@ func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
 			}, nil
 		}
 
-		panic("unexpected request")
+		return nil, errors.New("unexpected request")
 	}
 
 	expectedSummaryOfLatest := resources.BlockSummary{
-		Nonce:             4,
-		Hash:              "0004",
-		PreviousBlockHash: "0003",
-		Timestamp:         4,
+		Nonce:             3,
+		Hash:              "0003",
+		PreviousBlockHash: "0002",
+		Timestamp:         3,
 	}
 
 	expectedSummaryOfOldest := resources.BlockSummary{

--- a/server/resources/accountQueryOptions.go
+++ b/server/resources/accountQueryOptions.go
@@ -21,7 +21,10 @@ func NewAccountQueryOptionsOnFinalBlock() AccountQueryOptions {
 // NewAccountQueryOptionsWithBlockNonce creates an AccountQueryOptions (for a given block nonce)
 func NewAccountQueryOptionsWithBlockNonce(blockNonce uint64) AccountQueryOptions {
 	return AccountQueryOptions{
-		BlockNonce: core.OptionalUint64{Value: blockNonce, HasValue: true},
+		BlockNonce: core.OptionalUint64{
+			Value:    blockNonce,
+			HasValue: true,
+		},
 	}
 }
 

--- a/version/constants.go
+++ b/version/constants.go
@@ -5,7 +5,7 @@ const (
 	RosettaVersion = "v1.4.12"
 
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.2.0"
+	RosettaMiddlewareVersion = "v0.2.1"
 
 	// NodeVersion is the canonical version of the node runtime
 	NodeVersion = "rc/2022-july"


### PR DESCRIPTION
 - Account for rollback-related edge cases while node is syncing (in conjunction with scheduled miniblocks).
 - Adjust end conditions of `check:data`.
 - Minor refactoring.