### PR TITLE
Hotfix: hold block copies in the cache

### DIFF
--- a/server/provider/interface.go
+++ b/server/provider/interface.go
@@ -24,4 +24,5 @@ type blocksCache interface {
 	Put(key []byte, value interface{}, size int) (evicted bool)
 	Len() int
 	Keys() [][]byte
+	Clear()
 }

--- a/server/provider/networkProvider.go
+++ b/server/provider/networkProvider.go
@@ -251,7 +251,8 @@ func (provider *networkProvider) getBlockByNonceCached(nonce uint64) (*data.Bloc
 	if ok {
 		block, ok := blockUntyped.(*data.Block)
 		if ok {
-			return block, true
+			blockCopy := *block
+			return &blockCopy, true
 		}
 	}
 
@@ -259,7 +260,8 @@ func (provider *networkProvider) getBlockByNonceCached(nonce uint64) (*data.Bloc
 }
 
 func (provider *networkProvider) cacheBlockByNonce(nonce uint64, block *data.Block) {
-	_ = provider.blocksCache.Put(blockNonceToBytes(nonce), block, 1)
+	blockCopy := *block
+	_ = provider.blocksCache.Put(blockNonceToBytes(nonce), &blockCopy, 1)
 }
 
 // GetBlockByHash gets a block by hash

--- a/version/constants.go
+++ b/version/constants.go
@@ -5,7 +5,7 @@ const (
 	RosettaVersion = "v1.4.12"
 
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.2.2"
+	RosettaMiddlewareVersion = "v0.2.3"
 
 	// NodeVersion is the canonical version of the node runtime
 	// TODO: We should fetch this from node/status.


### PR DESCRIPTION
The cache should hold copies of the blocks, because the pointers returned by `GetBlockByNonce` suffer mutations downstream (e.g. due to `simplifyBlockWithScheduledTransactions`). Such mutations should not affect the cached data.