### PR TITLE
Fix fee computation for edge case "meta transaction is invalid".

### DIFF
--- a/server/services/constants.go
+++ b/server/services/constants.go
@@ -17,7 +17,7 @@ var (
 )
 
 var (
-	transactionEventSignalError            = "signalError"
-	transactionEventTransferValueOnly      = "transferValueOnly"
-	transactionEventInvalidMetaTransaction = "meta transaction is invalid"
+	transactionEventSignalError                 = "signalError"
+	transactionEventTransferValueOnly           = "transferValueOnly"
+	transactionEventTopicInvalidMetaTransaction = "meta transaction is invalid"
 )

--- a/server/services/constants.go
+++ b/server/services/constants.go
@@ -17,6 +17,7 @@ var (
 )
 
 var (
-	transactionEventSignalError       = "signalError"
-	transactionEventTransferValueOnly = "transferValueOnly"
+	transactionEventSignalError            = "signalError"
+	transactionEventTransferValueOnly      = "transferValueOnly"
+	transactionEventInvalidMetaTransaction = "meta transaction is invalid"
 )

--- a/server/services/transactionEventsController.go
+++ b/server/services/transactionEventsController.go
@@ -88,10 +88,9 @@ func (controller *transactionEventsController) hasSignalErrorOfMetaTransactionIs
 			continue
 		}
 
-		for _, topic := range event.Topics {
-			if string(topic) == transactionEventTopicInvalidMetaTransaction {
-				return true
-			}
+		hasTopicInvalidMetaTransaction := eventHasTopic(event, transactionEventTopicInvalidMetaTransaction)
+		if hasTopicInvalidMetaTransaction {
+			return true
 		}
 	}
 
@@ -100,4 +99,14 @@ func (controller *transactionEventsController) hasSignalErrorOfMetaTransactionIs
 
 func (controller *transactionEventsController) hasEvents(tx *data.FullTransaction) bool {
 	return tx.Logs != nil && tx.Logs.Events != nil && len(tx.Logs.Events) > 0
+}
+
+func eventHasTopic(event *transaction.Events, topicToFind string) bool {
+	for _, topic := range event.Topics {
+		if string(topic) == topicToFind {
+			return true
+		}
+	}
+
+	return false
 }

--- a/server/services/transactionEventsController.go
+++ b/server/services/transactionEventsController.go
@@ -77,6 +77,11 @@ func (controller *transactionEventsController) hasSignalErrorOfSendingValueToNon
 	return false
 }
 
+func (controller *transactionEventsController) hasSignalErrorOfMetaTransactionIsInvalid(tx *data.FullTransaction) bool {
+	_, err := controller.findEventByIdentifier(tx, transactionEventInvalidMetaTransaction)
+	return err == nil
+}
+
 func (controller *transactionEventsController) hasEvents(tx *data.FullTransaction) bool {
 	return tx.Logs != nil && tx.Logs.Events != nil && len(tx.Logs.Events) > 0
 }

--- a/server/services/transactionEventsController.go
+++ b/server/services/transactionEventsController.go
@@ -78,8 +78,24 @@ func (controller *transactionEventsController) hasSignalErrorOfSendingValueToNon
 }
 
 func (controller *transactionEventsController) hasSignalErrorOfMetaTransactionIsInvalid(tx *data.FullTransaction) bool {
-	_, err := controller.findEventByIdentifier(tx, transactionEventInvalidMetaTransaction)
-	return err == nil
+	if !controller.hasEvents(tx) {
+		return false
+	}
+
+	for _, event := range tx.Logs.Events {
+		isSignalError := event.Identifier == transactionEventSignalError
+		if !isSignalError {
+			continue
+		}
+
+		for _, topic := range event.Topics {
+			if string(topic) == transactionEventTopicInvalidMetaTransaction {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (controller *transactionEventsController) hasEvents(tx *data.FullTransaction) bool {

--- a/server/services/transactionEventsController_test.go
+++ b/server/services/transactionEventsController_test.go
@@ -1,0 +1,80 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+	"github.com/ElrondNetwork/rosetta/testscommon"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactionEventsController_HasSignalErrorOfSendingValueToNonPayableContract(t *testing.T) {
+	networkProvider := testscommon.NewNetworkProviderMock()
+	controller := newTransactionEventsController(networkProvider)
+
+	t.Run("arbitrary tx", func(t *testing.T) {
+		tx := &data.FullTransaction{}
+		txMatches := controller.hasSignalErrorOfSendingValueToNonPayableContract(tx)
+		require.False(t, txMatches)
+	})
+
+	t.Run("invalid tx with event 'sending value to non-payable contract'", func(t *testing.T) {
+		tx := &data.FullTransaction{
+			Logs: &transaction.ApiLogs{
+
+				Events: []*transaction.Events{
+					{
+						Identifier: transactionEventSignalError,
+						Data:       []byte(sendingValueToNonPayableContractDataPrefix + "aaaabbbbccccdddd"),
+					},
+				},
+			},
+		}
+
+		txMatches := controller.hasSignalErrorOfSendingValueToNonPayableContract(tx)
+		require.True(t, txMatches)
+	})
+}
+
+func TestTransactionEventsController_HasSignalErrorOfMetaTransactionIsInvalid(t *testing.T) {
+	networkProvider := testscommon.NewNetworkProviderMock()
+	controller := newTransactionEventsController(networkProvider)
+
+	t.Run("arbitrary tx", func(t *testing.T) {
+		tx := &data.FullTransaction{}
+		txMatches := controller.hasSignalErrorOfMetaTransactionIsInvalid(tx)
+		require.False(t, txMatches)
+	})
+
+	t.Run("invalid tx with event 'invalid meta transaction'", func(t *testing.T) {
+		tx := &data.FullTransaction{
+			Logs: &transaction.ApiLogs{
+
+				Events: []*transaction.Events{
+					{
+						Identifier: transactionEventSignalError,
+						Topics: [][]byte{
+							[]byte(transactionEventTopicInvalidMetaTransaction),
+						},
+					},
+				},
+			},
+		}
+
+		txMatches := controller.hasSignalErrorOfMetaTransactionIsInvalid(tx)
+		require.True(t, txMatches)
+	})
+}
+
+func TestEventHasTopic(t *testing.T) {
+	event := transaction.Events{
+		Identifier: transactionEventSignalError,
+		Topics: [][]byte{
+			[]byte("foo"),
+		},
+	}
+
+	require.True(t, eventHasTopic(&event, "foo"))
+	require.False(t, eventHasTopic(&event, "bar"))
+}

--- a/server/services/transactionsFeaturesDetector.go
+++ b/server/services/transactionsFeaturesDetector.go
@@ -53,6 +53,7 @@ func (extractor *transactionsFeaturesDetector) isInvalidTransactionOfTypeMoveBal
 		return false
 	}
 
+	// TODO: Analyze whether we can simplify the conditions below, or possibly discard them completely / replace them with simpler ones.
 	withSendingValueToNonPayableContract := extractor.eventsController.hasSignalErrorOfSendingValueToNonPayableContract(tx)
 	withMetaTransactionIsInvalid := extractor.eventsController.hasSignalErrorOfMetaTransactionIsInvalid(tx)
 	return withSendingValueToNonPayableContract || withMetaTransactionIsInvalid

--- a/server/services/transactionsFeaturesDetector_test.go
+++ b/server/services/transactionsFeaturesDetector_test.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+	"github.com/ElrondNetwork/rosetta/testscommon"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeaturesDetector_IsInvalidTransactionOfTypeMoveBalanceThatOnlyConsumesDataMovementGas(t *testing.T) {
+	networkProvider := testscommon.NewNetworkProviderMock()
+	detector := newTransactionsFeaturesDetector(networkProvider)
+
+	t.Run("arbitrary tx", func(t *testing.T) {
+		arbitraryTx := &data.FullTransaction{
+			Hash:     "aaaa",
+			Sender:   testscommon.TestAddressAlice,
+			Receiver: testscommon.TestAddressBob,
+			Value:    "1234",
+		}
+
+		featureDetected := detector.isInvalidTransactionOfTypeMoveBalanceThatOnlyConsumesDataMovementGas(arbitraryTx)
+		require.False(t, featureDetected)
+	})
+
+	t.Run("invalid tx with event 'sending value to non-payable contract'", func(t *testing.T) {
+		tx := &data.FullTransaction{
+			ProcessingTypeOnSource:      transactionProcessingTypeMoveBalance,
+			ProcessingTypeOnDestination: transactionProcessingTypeMoveBalance,
+			Hash:                        "bbbb",
+			Sender:                      testscommon.TestAddressAlice,
+			Receiver:                    testscommon.TestAddressOfContract,
+			Value:                       "1234",
+			Type:                        string(transaction.TxTypeInvalid),
+			Logs: &transaction.ApiLogs{
+
+				Events: []*transaction.Events{
+					{
+						Identifier: transactionEventSignalError,
+						Data:       []byte(sendingValueToNonPayableContractDataPrefix + "aaaabbbbccccdddd"),
+					},
+				},
+			},
+		}
+
+		featureDetected := detector.isInvalidTransactionOfTypeMoveBalanceThatOnlyConsumesDataMovementGas(tx)
+		require.True(t, featureDetected)
+	})
+
+	t.Run("invalid tx with event 'invalid meta transaction'", func(t *testing.T) {
+		tx := &data.FullTransaction{
+			ProcessingTypeOnSource:      transactionProcessingTypeMoveBalance,
+			ProcessingTypeOnDestination: transactionProcessingTypeMoveBalance,
+			Hash:                        "cccc",
+			Sender:                      testscommon.TestAddressAlice,
+			Receiver:                    testscommon.TestAddressOfContract,
+			Value:                       "1234",
+			Type:                        string(transaction.TxTypeInvalid),
+			Logs: &transaction.ApiLogs{
+
+				Events: []*transaction.Events{
+					{
+						Identifier: transactionEventSignalError,
+						Topics: [][]byte{
+							[]byte(transactionEventTopicInvalidMetaTransaction),
+						},
+					},
+				},
+			},
+		}
+
+		featureDetected := detector.isInvalidTransactionOfTypeMoveBalanceThatOnlyConsumesDataMovementGas(tx)
+		require.True(t, featureDetected)
+	})
+}

--- a/server/services/transactionsTransformer.go
+++ b/server/services/transactionsTransformer.go
@@ -217,7 +217,7 @@ func (transformer *transactionsTransformer) refundReceiptToRosettaTx(receipt *tr
 func (transformer *transactionsTransformer) invalidTxToRosettaTx(tx *data.FullTransaction) *types.Transaction {
 	fee := tx.InitiallyPaidFee
 
-	if transformer.featuresDetector.isInvalidTransactionOfSendingValueToNonPayableContractOfTypeMoveBalance(tx) {
+	if transformer.featuresDetector.isInvalidTransactionOfTypeMoveBalanceThatOnlyConsumesDataMovementGas(tx) {
 		// For this type of transactions, the fee only has the "data movement" component
 		// (we ignore tx.InitiallyPaidFee, which is not correctly provided in this case).
 		// Though, note that for built-in function calls (e.g. sending tokens using a transfer function) etc.,

--- a/version/constants.go
+++ b/version/constants.go
@@ -5,7 +5,7 @@ const (
 	RosettaVersion = "v1.4.12"
 
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.2.4"
+	RosettaMiddlewareVersion = "v0.2.5"
 
 	// NodeVersion is the canonical version of the node runtime
 	// TODO: We should fetch this from node/status.


### PR DESCRIPTION
For invalid transactions of type "move balance" (both at _source_ and at _destination_) that contain the error `invalid meta transaction`, compute used gas (and fee) using solely the data movement component (without the execution component).

Edge case has been discovered on devnet, _actual_ shard 0 (not _projected_ shard 0). The fix has been tested by running a `check:data` flow (see [rosetta-checks](https://github.com/ElrondNetwork/rosetta-checks)).