### PR TITLE
Provide a precise value for "oldest block identifier"

### DIFF
--- a/cmd/rosetta/cli.go
+++ b/cmd/rosetta/cli.go
@@ -127,12 +127,6 @@ VERSION:
 		Usage: "Specifies the symbol of the native currency (must be EGLD for mainnet, XeGLD for testnet and devnet).",
 		Value: "EGLD",
 	}
-
-	cliFlagNumHistoricalBlocks = cli.Uint64Flag{
-		Name:  "num-historical-blocks",
-		Usage: "Specifies the (approximate) number of available historical blocks. Usually, correlated with observer's `NumEpochsToKeep`.",
-		Value: 1500,
-	}
 )
 
 func getAllCliFlags() []cli.Flag {
@@ -154,7 +148,6 @@ func getAllCliFlags() []cli.Flag {
 		cliFlagMinGasLimit,
 		cliFlagGasPerDataByte,
 		cliFlagNativeCurrencySymbol,
-		cliFlagNumHistoricalBlocks,
 	}
 }
 
@@ -177,7 +170,6 @@ type parsedCliFlags struct {
 	minGasLimit                 uint64
 	gasPerDataByte              uint64
 	nativeCurrencySymbol        string
-	numHistoricalBlocks         uint64
 }
 
 func getParsedCliFlags(ctx *cli.Context) parsedCliFlags {
@@ -200,6 +192,5 @@ func getParsedCliFlags(ctx *cli.Context) parsedCliFlags {
 		minGasLimit:                 ctx.GlobalUint64(cliFlagMinGasLimit.Name),
 		gasPerDataByte:              ctx.GlobalUint64(cliFlagGasPerDataByte.Name),
 		nativeCurrencySymbol:        ctx.GlobalString(cliFlagNativeCurrencySymbol.Name),
-		numHistoricalBlocks:         ctx.GlobalUint64(cliFlagNumHistoricalBlocks.Name),
 	}
 }

--- a/cmd/rosetta/cli.go
+++ b/cmd/rosetta/cli.go
@@ -127,6 +127,18 @@ VERSION:
 		Usage: "Specifies the symbol of the native currency (must be EGLD for mainnet, XeGLD for testnet and devnet).",
 		Value: "EGLD",
 	}
+
+	cliFlagFirstHistoricalEpoch = cli.UintFlag{
+		Name:     "first-historical-epoch",
+		Usage:    "Specifies the first epoch with historical data available in Observer's database.",
+		Required: true,
+	}
+
+	cliFlagNumHistoricalEpochs = cli.UintFlag{
+		Name:     "num-historical-epochs",
+		Usage:    "Provides a hint for the number of historical epochs to be kept.",
+		Required: true,
+	}
 )
 
 func getAllCliFlags() []cli.Flag {
@@ -148,6 +160,8 @@ func getAllCliFlags() []cli.Flag {
 		cliFlagMinGasLimit,
 		cliFlagGasPerDataByte,
 		cliFlagNativeCurrencySymbol,
+		cliFlagFirstHistoricalEpoch,
+		cliFlagNumHistoricalEpochs,
 	}
 }
 
@@ -170,6 +184,8 @@ type parsedCliFlags struct {
 	minGasLimit                 uint64
 	gasPerDataByte              uint64
 	nativeCurrencySymbol        string
+	firstHistoricalEpoch        uint32
+	numHistoricalEpochs         uint32
 }
 
 func getParsedCliFlags(ctx *cli.Context) parsedCliFlags {
@@ -192,5 +208,7 @@ func getParsedCliFlags(ctx *cli.Context) parsedCliFlags {
 		minGasLimit:                 ctx.GlobalUint64(cliFlagMinGasLimit.Name),
 		gasPerDataByte:              ctx.GlobalUint64(cliFlagGasPerDataByte.Name),
 		nativeCurrencySymbol:        ctx.GlobalString(cliFlagNativeCurrencySymbol.Name),
+		firstHistoricalEpoch:        uint32(ctx.GlobalUint(cliFlagFirstHistoricalEpoch.Name)),
+		numHistoricalEpochs:         uint32(ctx.GlobalUint(cliFlagNumHistoricalEpochs.Name)),
 	}
 }

--- a/cmd/rosetta/main.go
+++ b/cmd/rosetta/main.go
@@ -70,7 +70,6 @@ func startRosetta(ctx *cli.Context) error {
 		MinGasLimit:                 cliFlags.minGasLimit,
 		NativeCurrencySymbol:        cliFlags.nativeCurrencySymbol,
 		GenesisBlockHash:            cliFlags.genesisBlock,
-		NumHistoricalBlocks:         cliFlags.numHistoricalBlocks,
 	})
 	if err != nil {
 		return err

--- a/cmd/rosetta/main.go
+++ b/cmd/rosetta/main.go
@@ -70,6 +70,8 @@ func startRosetta(ctx *cli.Context) error {
 		MinGasLimit:                 cliFlags.minGasLimit,
 		NativeCurrencySymbol:        cliFlags.nativeCurrencySymbol,
 		GenesisBlockHash:            cliFlags.genesisBlock,
+		FirstHistoricalEpoch:        cliFlags.firstHistoricalEpoch,
+		NumHistoricalEpochs:         cliFlags.numHistoricalEpochs,
 	})
 	if err != nil {
 		return err

--- a/server/factory/provider.go
+++ b/server/factory/provider.go
@@ -40,6 +40,8 @@ type ArgsCreateNetworkProvider struct {
 	NativeCurrencySymbol        string
 	GenesisBlockHash            string
 	GenesisTimestamp            int64
+	FirstHistoricalEpoch        uint32
+	NumHistoricalEpochs         uint32
 }
 
 // CreateNetworkProvider creates a network provider
@@ -123,6 +125,8 @@ func CreateNetworkProvider(args ArgsCreateNetworkProvider) (networkProvider, err
 		NativeCurrencySymbol:        args.NativeCurrencySymbol,
 		GenesisBlockHash:            args.GenesisBlockHash,
 		GenesisTimestamp:            args.GenesisTimestamp,
+		FirstHistoricalEpoch:        args.FirstHistoricalEpoch,
+		NumHistoricalEpochs:         args.NumHistoricalEpochs,
 
 		ObserverFacade: &components.ObserverFacade{
 			Processor:            baseProcessor,

--- a/server/factory/provider.go
+++ b/server/factory/provider.go
@@ -40,7 +40,6 @@ type ArgsCreateNetworkProvider struct {
 	NativeCurrencySymbol        string
 	GenesisBlockHash            string
 	GenesisTimestamp            int64
-	NumHistoricalBlocks         uint64
 }
 
 // CreateNetworkProvider creates a network provider
@@ -124,7 +123,6 @@ func CreateNetworkProvider(args ArgsCreateNetworkProvider) (networkProvider, err
 		NativeCurrencySymbol:        args.NativeCurrencySymbol,
 		GenesisBlockHash:            args.GenesisBlockHash,
 		GenesisTimestamp:            args.GenesisTimestamp,
-		NumHistoricalBlocks:         args.NumHistoricalBlocks,
 
 		ObserverFacade: &components.ObserverFacade{
 			Processor:            baseProcessor,

--- a/server/provider/constants.go
+++ b/server/provider/constants.go
@@ -3,9 +3,7 @@ package provider
 var (
 	nativeCurrencyNumDecimals = 18
 	genesisBlockNonce         = 0
-	// Block with nonce = 0 is not actually retrievable from the observer
-	oldestPossibleNonceWithHistoricalState = uint64(1)
-	blocksCacheCapacity                    = 256
+	blocksCacheCapacity       = 256
 )
 
 type MiniblockProcessingType string

--- a/server/provider/networkProvider.go
+++ b/server/provider/networkProvider.go
@@ -34,7 +34,6 @@ type ArgsNewNetworkProvider struct {
 	NativeCurrencySymbol        string
 	GenesisBlockHash            string
 	GenesisTimestamp            int64
-	NumHistoricalBlocks         uint64
 
 	ObserverFacade observerFacade
 
@@ -53,7 +52,6 @@ type networkProvider struct {
 	nativeCurrencySymbol        string
 	genesisBlockHash            string
 	genesisTimestamp            int64
-	numHistoricalBlocks         uint64
 
 	observerFacade observerFacade
 
@@ -85,7 +83,6 @@ func NewNetworkProvider(args ArgsNewNetworkProvider) (*networkProvider, error) {
 		nativeCurrencySymbol:        args.NativeCurrencySymbol,
 		genesisBlockHash:            args.GenesisBlockHash,
 		genesisTimestamp:            args.GenesisTimestamp,
-		numHistoricalBlocks:         args.NumHistoricalBlocks,
 
 		observerFacade: args.ObserverFacade,
 

--- a/server/provider/networkProvider.go
+++ b/server/provider/networkProvider.go
@@ -34,6 +34,8 @@ type ArgsNewNetworkProvider struct {
 	NativeCurrencySymbol        string
 	GenesisBlockHash            string
 	GenesisTimestamp            int64
+	FirstHistoricalEpoch        uint32
+	NumHistoricalEpochs         uint32
 
 	ObserverFacade observerFacade
 
@@ -52,6 +54,8 @@ type networkProvider struct {
 	nativeCurrencySymbol        string
 	genesisBlockHash            string
 	genesisTimestamp            int64
+	firstHistoricalEpoch        uint32
+	numHistoricalEpochs         uint32
 
 	observerFacade observerFacade
 
@@ -83,6 +87,8 @@ func NewNetworkProvider(args ArgsNewNetworkProvider) (*networkProvider, error) {
 		nativeCurrencySymbol:        args.NativeCurrencySymbol,
 		genesisBlockHash:            args.GenesisBlockHash,
 		genesisTimestamp:            args.GenesisTimestamp,
+		firstHistoricalEpoch:        args.FirstHistoricalEpoch,
+		numHistoricalEpochs:         args.NumHistoricalEpochs,
 
 		observerFacade: args.ObserverFacade,
 

--- a/server/provider/networkProvider.go
+++ b/server/provider/networkProvider.go
@@ -418,5 +418,7 @@ func (provider *networkProvider) LogDescription() {
 		"observedProjectedShard", provider.observedProjectedShard,
 		"observedProjectedShardIsSet", provider.observedProjectedShardIsSet,
 		"nativeCurrency", provider.nativeCurrencySymbol,
+		"firstHistoricalEpoch", provider.firstHistoricalEpoch,
+		"numHistoricalEpochs", provider.numHistoricalEpochs,
 	)
 }

--- a/server/provider/networkProvider_test.go
+++ b/server/provider/networkProvider_test.go
@@ -180,6 +180,5 @@ func createDefaultArgsNewNetworkProvider() ArgsNewNetworkProvider {
 		Hasher:                      testscommon.RealWorldBlake2bHasher,
 		MarshalizerForHashing:       testscommon.MarshalizerForHashing,
 		PubKeyConverter:             testscommon.RealWorldBech32PubkeyConverter,
-		NumHistoricalBlocks:         10000,
 	}
 }

--- a/server/provider/networkProvider_test.go
+++ b/server/provider/networkProvider_test.go
@@ -28,6 +28,8 @@ func TestNewNetworkProvider(t *testing.T) {
 		NativeCurrencySymbol:        "XeGLD",
 		GenesisBlockHash:            "aaaa",
 		GenesisTimestamp:            123456789,
+		FirstHistoricalEpoch:        1000,
+		NumHistoricalEpochs:         1024,
 		ObserverFacade:              testscommon.NewObserverFacadeMock(),
 		Hasher:                      testscommon.RealWorldBlake2bHasher,
 		MarshalizerForHashing:       testscommon.MarshalizerForHashing,
@@ -52,6 +54,8 @@ func TestNewNetworkProvider(t *testing.T) {
 	assert.Equal(t, "XeGLD", provider.GetNativeCurrency().Symbol)
 	assert.Equal(t, "aaaa", provider.GetGenesisBlockSummary().Hash)
 	assert.Equal(t, int64(123456789), provider.GetGenesisTimestamp())
+	assert.Equal(t, uint32(1000), provider.firstHistoricalEpoch)
+	assert.Equal(t, uint32(1024), provider.numHistoricalEpochs)
 }
 
 func TestNetworkProvider_DoGetBlockByNonce(t *testing.T) {

--- a/server/provider/nodeStatus.go
+++ b/server/provider/nodeStatus.go
@@ -62,10 +62,5 @@ func getLatestNonceGivenHighestFinalNonce(highestFinalNonce uint64) uint64 {
 }
 
 func (provider *networkProvider) getOldestNonceWithHistoricalStateGivenNodeStatus(status *resources.NodeStatus) uint64 {
-	oldest := int64(status.HighestFinalNonce) - int64(provider.numHistoricalBlocks)
-	if oldest < int64(oldestPossibleNonceWithHistoricalState) {
-		return oldestPossibleNonceWithHistoricalState
-	}
-
-	return uint64(oldest)
+	return oldestPossibleNonceWithHistoricalState
 }

--- a/server/provider/nodeStatus.go
+++ b/server/provider/nodeStatus.go
@@ -66,14 +66,18 @@ func getLatestNonceGivenHighestFinalNonce(highestFinalNonce uint64) uint64 {
 }
 
 func (provider *networkProvider) getOldestNonceWithHistoricalStateGivenNodeStatus(status *resources.NodeStatus) (uint64, error) {
-	// Avoid eventual snapshotting-related edge-cases by not considering the 2 oldest kept epochs.
-	oldestEligibleEpoch := status.OldestKeptEpoch + 2
+	oldestEligibleEpoch := getOldestEligibleEpochGivenOldestKeptEpoch(status.OldestKeptEpoch)
 	epochStartInfo, err := provider.getEpochStartInfo(oldestEligibleEpoch)
 	if err != nil {
 		return 0, err
 	}
 
 	return epochStartInfo.Nonce, nil
+}
+
+func getOldestEligibleEpochGivenOldestKeptEpoch(oldestKeptEpoch uint32) uint32 {
+	// Avoid eventual snapshotting-related edge-cases by not considering the 2 oldest kept epochs.
+	return oldestKeptEpoch + 2
 }
 
 func (provider *networkProvider) getEpochStartInfo(epoch uint32) (*resources.EpochStart, error) {

--- a/server/provider/nodeStatus_test.go
+++ b/server/provider/nodeStatus_test.go
@@ -107,7 +107,6 @@ func TestNetworkProvider_GetNodeStatusWithError(t *testing.T) {
 
 func TestGetOldestNonceWithHistoricalStateGivenNodeStatus(t *testing.T) {
 	args := createDefaultArgsNewNetworkProvider()
-	args.NumHistoricalBlocks = 42
 	provider, err := NewNetworkProvider(args)
 	require.Nil(t, err)
 	require.NotNil(t, provider)

--- a/server/provider/nodeStatus_test.go
+++ b/server/provider/nodeStatus_test.go
@@ -15,6 +15,8 @@ func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
 	observerFacade := testscommon.NewObserverFacadeMock()
 	args := createDefaultArgsNewNetworkProvider()
 	args.ObserverFacade = observerFacade
+	args.FirstHistoricalEpoch = 2
+	args.NumHistoricalEpochs = 8
 
 	provider, err := NewNetworkProvider(args)
 	require.Nil(t, err)
@@ -27,18 +29,18 @@ func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
 					IsSyncing:         1,
 					HighestNonce:      1005,
 					HighestFinalNonce: 1000,
-					OldestKeptEpoch:   3,
+					CurrentEpoch:      11,
 				},
 			}
 
 			return 0, nil
 		}
 
-		// 5 = OldestKeptEpoch + 2
-		if path == "/node/epoch-start/5" {
+		// 3 = max(11 - 8, 2)
+		if path == "/node/epoch-start/3" {
 			value.(*resources.EpochStartApiResponse).Data = resources.EpochStartApiResponsePayload{
 				EpochStart: resources.EpochStart{
-					Nonce: 500,
+					Nonce: 300,
 				},
 			}
 
@@ -64,14 +66,14 @@ func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
 		}
 
 		// Oldest nonce with historical state
-		if nonce == 500 {
+		if nonce == 300 {
 			return &data.BlockApiResponse{
 				Data: data.BlockApiResponsePayload{
 					Block: data.Block{
-						Nonce:         500,
-						Hash:          "00000500",
-						PrevBlockHash: "00000499",
-						Timestamp:     500,
+						Nonce:         300,
+						Hash:          "00000300",
+						PrevBlockHash: "00000299",
+						Timestamp:     300,
 					},
 				},
 			}, nil
@@ -88,10 +90,10 @@ func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
 	}
 
 	expectedSummaryOfOldest := resources.BlockSummary{
-		Nonce:             500,
-		Hash:              "00000500",
-		PreviousBlockHash: "00000499",
-		Timestamp:         500,
+		Nonce:             300,
+		Hash:              "00000300",
+		PreviousBlockHash: "00000299",
+		Timestamp:         300,
 	}
 
 	nodeStatus, err := provider.GetNodeStatus()
@@ -123,23 +125,38 @@ func TestGetOldestNonceWithHistoricalStateGivenNodeStatus(t *testing.T) {
 	observerFacade := testscommon.NewObserverFacadeMock()
 	args := createDefaultArgsNewNetworkProvider()
 	args.ObserverFacade = observerFacade
+	args.FirstHistoricalEpoch = 2
+	args.NumHistoricalEpochs = 8
 
 	provider, err := NewNetworkProvider(args)
 	require.Nil(t, err)
 	require.NotNil(t, provider)
 
 	observerFacade.CallGetRestEndPointCalled = func(baseUrl, path string, value interface{}) (int, error) {
-		if path == "/node/epoch-start/5" {
+		// 2 = max(7 - 8, 2)
+		if path == "/node/epoch-start/2" {
 			value.(*resources.EpochStartApiResponse).Data = resources.EpochStartApiResponsePayload{
 				EpochStart: resources.EpochStart{
-					Nonce: 500,
+					Nonce: 200,
 				},
 			}
 
 			return 0, nil
 		}
 
+		// 3 = max(11 - 8, 2)
 		if path == "/node/epoch-start/3" {
+			value.(*resources.EpochStartApiResponse).Data = resources.EpochStartApiResponsePayload{
+				EpochStart: resources.EpochStart{
+					Nonce: 300,
+				},
+			}
+
+			return 0, nil
+		}
+
+		// 42 = 50 - 8
+		if path == "/node/epoch-start/42" {
 			return 0, errors.New("arbitrary error")
 		}
 
@@ -147,14 +164,41 @@ func TestGetOldestNonceWithHistoricalStateGivenNodeStatus(t *testing.T) {
 	}
 
 	oldestNonce, err := provider.getOldestNonceWithHistoricalStateGivenNodeStatus(&resources.NodeStatus{
-		OldestKeptEpoch: 3,
+		CurrentEpoch: 7,
 	})
 	require.Nil(t, err)
-	require.Equal(t, uint64(500), oldestNonce)
+	require.Equal(t, uint64(200), oldestNonce)
 
 	oldestNonce, err = provider.getOldestNonceWithHistoricalStateGivenNodeStatus(&resources.NodeStatus{
-		OldestKeptEpoch: 1,
+		CurrentEpoch: 11,
+	})
+	require.Nil(t, err)
+	require.Equal(t, uint64(300), oldestNonce)
+
+	oldestNonce, err = provider.getOldestNonceWithHistoricalStateGivenNodeStatus(&resources.NodeStatus{
+		CurrentEpoch: 50,
 	})
 	require.Equal(t, uint64(0), oldestNonce)
 	require.ErrorContains(t, err, "arbitrary error")
+}
+
+func TestGetOldestEligibleEpoch(t *testing.T) {
+	observerFacade := testscommon.NewObserverFacadeMock()
+	args := createDefaultArgsNewNetworkProvider()
+	args.ObserverFacade = observerFacade
+	args.FirstHistoricalEpoch = 2
+	args.NumHistoricalEpochs = 8
+
+	provider, err := NewNetworkProvider(args)
+	require.Nil(t, err)
+	require.NotNil(t, provider)
+
+	epoch := provider.getOldestEligibleEpoch(7)
+	require.Equal(t, uint32(2), epoch)
+
+	epoch = provider.getOldestEligibleEpoch(11)
+	require.Equal(t, uint32(3), epoch)
+
+	epoch = provider.getOldestEligibleEpoch(100)
+	require.Equal(t, uint32(92), epoch)
 }

--- a/server/provider/nodeStatus_test.go
+++ b/server/provider/nodeStatus_test.go
@@ -25,39 +25,53 @@ func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
 			value.(*resources.NodeStatusApiResponse).Data = resources.NodeStatusApiResponsePayload{
 				Status: resources.NodeStatus{
 					IsSyncing:         1,
-					HighestNonce:      7,
-					HighestFinalNonce: 5,
+					HighestNonce:      1005,
+					HighestFinalNonce: 1000,
+					OldestKeptEpoch:   3,
 				},
 			}
+
+			return 0, nil
 		}
 
-		return 0, nil
+		// 5 = OldestKeptEpoch + 2
+		if path == "/node/epoch-start/5" {
+			value.(*resources.EpochStartApiResponse).Data = resources.EpochStartApiResponsePayload{
+				EpochStart: resources.EpochStart{
+					Nonce: 500,
+				},
+			}
+
+			return 0, nil
+		}
+
+		return 0, errors.New("unexpected request")
 	}
 
 	observerFacade.GetBlockByNonceCalled = func(shardID uint32, nonce uint64, options common.BlockQueryOptions) (*data.BlockApiResponse, error) {
-		// The one before "HighestFinalNonce"
-		if nonce == 3 {
+		// 998 = HighestFinalNonce - 2
+		if nonce == 998 {
 			return &data.BlockApiResponse{
 				Data: data.BlockApiResponsePayload{
 					Block: data.Block{
-						Nonce:         3,
-						Hash:          "0003",
-						PrevBlockHash: "0002",
-						Timestamp:     3,
+						Nonce:         998,
+						Hash:          "00000998",
+						PrevBlockHash: "00000997",
+						Timestamp:     998,
 					},
 				},
 			}, nil
 		}
 
-		// Oldest nonce with historical state (as considered by Rosetta)
-		if nonce == 1 {
+		// Oldest nonce with historical state
+		if nonce == 500 {
 			return &data.BlockApiResponse{
 				Data: data.BlockApiResponsePayload{
 					Block: data.Block{
-						Nonce:         1,
-						Hash:          "0001",
-						PrevBlockHash: "0000",
-						Timestamp:     1,
+						Nonce:         500,
+						Hash:          "00000500",
+						PrevBlockHash: "00000499",
+						Timestamp:     500,
 					},
 				},
 			}, nil
@@ -67,17 +81,17 @@ func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
 	}
 
 	expectedSummaryOfLatest := resources.BlockSummary{
-		Nonce:             3,
-		Hash:              "0003",
-		PreviousBlockHash: "0002",
-		Timestamp:         3,
+		Nonce:             998,
+		Hash:              "00000998",
+		PreviousBlockHash: "00000997",
+		Timestamp:         998,
 	}
 
 	expectedSummaryOfOldest := resources.BlockSummary{
-		Nonce:             1,
-		Hash:              "0001",
-		PreviousBlockHash: "0000",
-		Timestamp:         1,
+		Nonce:             500,
+		Hash:              "00000500",
+		PreviousBlockHash: "00000499",
+		Timestamp:         500,
 	}
 
 	nodeStatus, err := provider.GetNodeStatus()
@@ -106,20 +120,41 @@ func TestNetworkProvider_GetNodeStatusWithError(t *testing.T) {
 }
 
 func TestGetOldestNonceWithHistoricalStateGivenNodeStatus(t *testing.T) {
+	observerFacade := testscommon.NewObserverFacadeMock()
 	args := createDefaultArgsNewNetworkProvider()
+	args.ObserverFacade = observerFacade
+
 	provider, err := NewNetworkProvider(args)
 	require.Nil(t, err)
 	require.NotNil(t, provider)
 
-	oldestNonce := provider.getOldestNonceWithHistoricalStateGivenNodeStatus(&resources.NodeStatus{
-		HighestFinalNonce: 50,
+	observerFacade.CallGetRestEndPointCalled = func(baseUrl, path string, value interface{}) (int, error) {
+		if path == "/node/epoch-start/5" {
+			value.(*resources.EpochStartApiResponse).Data = resources.EpochStartApiResponsePayload{
+				EpochStart: resources.EpochStart{
+					Nonce: 500,
+				},
+			}
+
+			return 0, nil
+		}
+
+		if path == "/node/epoch-start/3" {
+			return 0, errors.New("arbitrary error")
+		}
+
+		return 0, errors.New("unexpected request")
+	}
+
+	oldestNonce, err := provider.getOldestNonceWithHistoricalStateGivenNodeStatus(&resources.NodeStatus{
+		OldestKeptEpoch: 3,
 	})
+	require.Nil(t, err)
+	require.Equal(t, uint64(500), oldestNonce)
 
-	require.Equal(t, uint64(8), oldestNonce)
-
-	oldestNonce = provider.getOldestNonceWithHistoricalStateGivenNodeStatus(&resources.NodeStatus{
-		HighestFinalNonce: 40,
+	oldestNonce, err = provider.getOldestNonceWithHistoricalStateGivenNodeStatus(&resources.NodeStatus{
+		OldestKeptEpoch: 1,
 	})
-
-	require.Equal(t, uint64(1), oldestNonce)
+	require.Equal(t, uint64(0), oldestNonce)
+	require.ErrorContains(t, err, "arbitrary error")
 }

--- a/server/provider/urls.go
+++ b/server/provider/urls.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	urlPathGetNodeStatus                        = "/node/status"
+	urlPathGetEpochStartInfo                    = "/node/epoch-start/%d"
 	urlPathGetGenesisBalances                   = "/network/genesis-balances"
 	urlPathGetAccount                           = "/address/%s"
 	urlPathGetAccountNativeBalance              = "/address/%s/balance"
@@ -19,6 +20,10 @@ var (
 	urlParameterAccountQueryOptionsBlockNonce   = "blockNonce"
 	urlParameterAccountQueryOptionsBlockHash    = "blockHash"
 )
+
+func buildUrlGetEpochStartInfo(epoch uint32) string {
+	return fmt.Sprintf(urlPathGetEpochStartInfo, epoch)
+}
 
 func buildUrlGetAccount(address string) string {
 	options := resources.NewAccountQueryOptionsOnFinalBlock()

--- a/server/resources/network.go
+++ b/server/resources/network.go
@@ -25,6 +25,23 @@ type NodeStatus struct {
 	IsSyncing         int    `json:"erd_is_syncing"`
 	HighestNonce      uint64 `json:"erd_nonce"`
 	HighestFinalNonce uint64 `json:"erd_highest_final_nonce"`
+	OldestKeptEpoch   uint32 `json:"erd_oldest_kept_epoch"`
+}
+
+// EpochStartApiResponse is an API resource
+type EpochStartApiResponse struct {
+	resourceApiResponse
+	Data EpochStartApiResponsePayload `json:"data"`
+}
+
+// EpochStartApiResponsePayload is an API resource
+type EpochStartApiResponsePayload struct {
+	EpochStart EpochStart `json:"epochStart"`
+}
+
+// EpochStart is an API resource
+type EpochStart struct {
+	Nonce uint64 `json:"nonce"`
 }
 
 // AggregatedNodeStatus is an aggregated resource

--- a/server/resources/network.go
+++ b/server/resources/network.go
@@ -25,7 +25,7 @@ type NodeStatus struct {
 	IsSyncing         int    `json:"erd_is_syncing"`
 	HighestNonce      uint64 `json:"erd_nonce"`
 	HighestFinalNonce uint64 `json:"erd_highest_final_nonce"`
-	OldestKeptEpoch   uint32 `json:"erd_oldest_kept_epoch"`
+	CurrentEpoch      uint32 `json:"erd_epoch_number"`
 }
 
 // EpochStartApiResponse is an API resource

--- a/version/constants.go
+++ b/version/constants.go
@@ -5,9 +5,9 @@ const (
 	RosettaVersion = "v1.4.12"
 
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.2.6"
+	RosettaMiddlewareVersion = "v0.2.7"
 
 	// NodeVersion is the canonical version of the node runtime
 	// TODO: We should fetch this from node/status.
-	NodeVersion = "v1.3.42"
+	NodeVersion = "feat/rosetta"
 )


### PR DESCRIPTION
Previously, rosetta provided an estimation for `oldest_block_identifier` (relying on a CLI argument called `--num-historical-blocks`). Here, we remove the estimation logic, and provide a precise value, instead.

In order to provide a precise value for `oldest_block_identifier`, rely on:
 - `oldest_kept_epoch` provided by `node/status` (metric recently added on Node API)
 - `node/epoch-start` (route recently added on Node API)

PR on elrond-go that is used as a basis for the implementation: https://github.com/ElrondNetwork/elrond-go/pull/4505