### PR TITLE
Add transaction metadata. Make some operation types more explicit.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/rosetta
 go 1.18
 
 require (
-	github.com/ElrondNetwork/elrond-go v1.3.42
+	github.com/ElrondNetwork/elrond-go v1.3.43-rosetta1
 	github.com/ElrondNetwork/elrond-go-core v1.1.19
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
 	github.com/ElrondNetwork/elrond-go-storage v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/ElrondNetwork/concurrent-map v0.1.3/go.mod h1:3XwSwn4JHI0lrKxWLZvtp53
 github.com/ElrondNetwork/covalent-indexer-go v1.0.6/go.mod h1:j3h2g96vqhJAuj3aEX2PWhomae2/o7YfXGEfweNXEeQ=
 github.com/ElrondNetwork/elastic-indexer-go v1.2.41 h1:Z3Ae8BCRloB4dyrWMJtGGMgpCD3gAH6iNmscKcTt0so=
 github.com/ElrondNetwork/elastic-indexer-go v1.2.41/go.mod h1:w+J48ssy1kxOawG2lwiOUR4JYPA092g8Zjk88kRVDNA=
-github.com/ElrondNetwork/elrond-go v1.3.42 h1:7hs6DKZPGNKT37l62vYa8NLdBE+2JIGcQ7KuK8s2lmM=
-github.com/ElrondNetwork/elrond-go v1.3.42/go.mod h1:IxJvn7Y2A9uN9S/JJdD3glST0hfy3W0LZCkhiSogHVw=
+github.com/ElrondNetwork/elrond-go v1.3.43-rosetta1 h1:NaX7CrcFA+ekOrGZEWXOQ867HTlSd97KSQvwuAXne6Y=
+github.com/ElrondNetwork/elrond-go v1.3.43-rosetta1/go.mod h1:IxJvn7Y2A9uN9S/JJdD3glST0hfy3W0LZCkhiSogHVw=
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.13/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=

--- a/server/provider/errors.go
+++ b/server/provider/errors.go
@@ -10,6 +10,7 @@ var errIsOffline = errors.New("server is in offline mode")
 var errCannotGetBlock = errors.New("cannot get block")
 var errCannotGetAccount = errors.New("cannot get account")
 var errCannotGetTransaction = errors.New("cannot get transaction")
+var errCannotGetLatestBlockNonce = errors.New("cannot get latest block nonce, maybe the node didn't start syncing")
 
 func newErrCannotGetBlockByNonce(nonce uint64, innerError error) error {
 	return fmt.Errorf("%w: %v, nonce = %d", errCannotGetBlock, innerError, nonce)

--- a/server/provider/nodeStatus.go
+++ b/server/provider/nodeStatus.go
@@ -13,7 +13,11 @@ func (provider *networkProvider) GetNodeStatus() (*resources.AggregatedNodeStatu
 		return nil, err
 	}
 
-	latestNonce := getLatestNonceGivenHighestFinalNonce(plainNodeStatus.HighestFinalNonce)
+	latestNonce, err := getLatestNonceGivenHighestFinalNonce(plainNodeStatus.HighestFinalNonce)
+	if err != nil {
+		return nil, err
+	}
+
 	latestBlockSummary, err := provider.getBlockSummaryByNonce(latestNonce)
 	if err != nil {
 		return nil, err
@@ -57,12 +61,17 @@ func (provider *networkProvider) getLatestBlockNonce() (uint64, error) {
 	}
 
 	// In the context of scheduled transactions, make sure the N+1 block is final, as well.
-	return getLatestNonceGivenHighestFinalNonce(nodeStatus.HighestFinalNonce), nil
+	return getLatestNonceGivenHighestFinalNonce(nodeStatus.HighestFinalNonce)
 }
 
-func getLatestNonceGivenHighestFinalNonce(highestFinalNonce uint64) uint64 {
+func getLatestNonceGivenHighestFinalNonce(highestFinalNonce uint64) (uint64, error) {
 	// Account for rollback-related edge cases while node is syncing (in conjunction with scheduled miniblocks).
-	return highestFinalNonce - 2
+	const nonceDelta = 2
+
+	if highestFinalNonce <= nonceDelta {
+		return 0, errCannotGetLatestBlockNonce
+	}
+	return highestFinalNonce - nonceDelta, nil
 }
 
 func (provider *networkProvider) getOldestNonceWithHistoricalStateGivenNodeStatus(status *resources.NodeStatus) (uint64, error) {

--- a/server/provider/nodeStatus.go
+++ b/server/provider/nodeStatus.go
@@ -71,6 +71,7 @@ func getLatestNonceGivenHighestFinalNonce(highestFinalNonce uint64) (uint64, err
 	if highestFinalNonce <= nonceDelta {
 		return 0, errCannotGetLatestBlockNonce
 	}
+
 	return highestFinalNonce - nonceDelta, nil
 }
 

--- a/server/provider/nodeStatus_test.go
+++ b/server/provider/nodeStatus_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
+	t.Parallel()
+
 	observerFacade := testscommon.NewObserverFacadeMock()
 	args := createDefaultArgsNewNetworkProvider()
 	args.ObserverFacade = observerFacade
@@ -105,6 +107,8 @@ func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
 }
 
 func TestNetworkProvider_GetNodeStatusWithError(t *testing.T) {
+	t.Parallel()
+
 	observerFacade := testscommon.NewObserverFacadeMock()
 	args := createDefaultArgsNewNetworkProvider()
 	args.ObserverFacade = observerFacade
@@ -137,6 +141,8 @@ func TestNetworkProvider_GetNodeStatusWithError(t *testing.T) {
 }
 
 func TestNetworkProvider_GetLatestBlockNonce(t *testing.T) {
+	t.Parallel()
+
 	observerFacade := testscommon.NewObserverFacadeMock()
 	args := createDefaultArgsNewNetworkProvider()
 	args.ObserverFacade = observerFacade
@@ -148,6 +154,8 @@ func TestNetworkProvider_GetLatestBlockNonce(t *testing.T) {
 	require.NotNil(t, provider)
 
 	t.Run("when HighestFinalNonce <= 2 (node didn't start syncing)", func(t *testing.T) {
+		t.Parallel()
+
 		observerFacade.CallGetRestEndPointCalled = func(baseUrl, path string, value interface{}) (int, error) {
 			if path == "/node/status" {
 				value.(*resources.NodeStatusApiResponse).Data = resources.NodeStatusApiResponsePayload{
@@ -168,6 +176,8 @@ func TestNetworkProvider_GetLatestBlockNonce(t *testing.T) {
 	})
 
 	t.Run("when HighestFinalNonce > 2", func(t *testing.T) {
+		t.Parallel()
+
 		observerFacade.CallGetRestEndPointCalled = func(baseUrl, path string, value interface{}) (int, error) {
 			if path == "/node/status" {
 				value.(*resources.NodeStatusApiResponse).Data = resources.NodeStatusApiResponsePayload{
@@ -189,6 +199,8 @@ func TestNetworkProvider_GetLatestBlockNonce(t *testing.T) {
 }
 
 func TestGetOldestNonceWithHistoricalStateGivenNodeStatus(t *testing.T) {
+	t.Parallel()
+
 	observerFacade := testscommon.NewObserverFacadeMock()
 	args := createDefaultArgsNewNetworkProvider()
 	args.ObserverFacade = observerFacade
@@ -250,6 +262,8 @@ func TestGetOldestNonceWithHistoricalStateGivenNodeStatus(t *testing.T) {
 }
 
 func TestGetOldestEligibleEpoch(t *testing.T) {
+	t.Parallel()
+
 	observerFacade := testscommon.NewObserverFacadeMock()
 	args := createDefaultArgsNewNetworkProvider()
 	args.ObserverFacade = observerFacade

--- a/server/provider/nodeStatus_test.go
+++ b/server/provider/nodeStatus_test.go
@@ -113,6 +113,20 @@ func TestNetworkProvider_GetNodeStatusWithError(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, provider)
 
+	observerFacade.CallGetRestEndPointCalled = func(baseUrl, path string, value interface{}) (int, error) {
+		if path == "/node/status" {
+			value.(*resources.NodeStatusApiResponse).Data = resources.NodeStatusApiResponsePayload{
+				Status: resources.NodeStatus{
+					HighestFinalNonce: 42,
+				},
+			}
+
+			return 0, nil
+		}
+
+		return 0, errors.New("unexpected request")
+	}
+
 	observerFacade.GetBlockByNonceCalled = func(shardID uint32, nonce uint64, options common.BlockQueryOptions) (*data.BlockApiResponse, error) {
 		return nil, errors.New("arbitrary error")
 	}
@@ -120,6 +134,58 @@ func TestNetworkProvider_GetNodeStatusWithError(t *testing.T) {
 	nodeStatus, err := provider.GetNodeStatus()
 	require.Nil(t, nodeStatus)
 	require.ErrorContains(t, err, "arbitrary error")
+}
+
+func TestNetworkProvider_GetLatestBlockNonce(t *testing.T) {
+	observerFacade := testscommon.NewObserverFacadeMock()
+	args := createDefaultArgsNewNetworkProvider()
+	args.ObserverFacade = observerFacade
+	args.FirstHistoricalEpoch = 2
+	args.NumHistoricalEpochs = 8
+
+	provider, err := NewNetworkProvider(args)
+	require.Nil(t, err)
+	require.NotNil(t, provider)
+
+	t.Run("when HighestFinalNonce <= 2 (node didn't start syncing)", func(t *testing.T) {
+		observerFacade.CallGetRestEndPointCalled = func(baseUrl, path string, value interface{}) (int, error) {
+			if path == "/node/status" {
+				value.(*resources.NodeStatusApiResponse).Data = resources.NodeStatusApiResponsePayload{
+					Status: resources.NodeStatus{
+						HighestFinalNonce: 0,
+					},
+				}
+
+				return 0, nil
+			}
+
+			return 0, errors.New("unexpected request")
+		}
+
+		nonce, err := provider.getLatestBlockNonce()
+		require.Error(t, errCannotGetLatestBlockNonce, err)
+		require.Equal(t, uint64(0), nonce)
+	})
+
+	t.Run("when HighestFinalNonce > 2", func(t *testing.T) {
+		observerFacade.CallGetRestEndPointCalled = func(baseUrl, path string, value interface{}) (int, error) {
+			if path == "/node/status" {
+				value.(*resources.NodeStatusApiResponse).Data = resources.NodeStatusApiResponsePayload{
+					Status: resources.NodeStatus{
+						HighestFinalNonce: 42,
+					},
+				}
+
+				return 0, nil
+			}
+
+			return 0, errors.New("unexpected request")
+		}
+
+		nonce, err := provider.getLatestBlockNonce()
+		require.Nil(t, err)
+		require.Equal(t, uint64(40), nonce)
+	})
 }
 
 func TestGetOldestNonceWithHistoricalStateGivenNodeStatus(t *testing.T) {

--- a/server/services/blockService_test.go
+++ b/server/services/blockService_test.go
@@ -17,6 +17,15 @@ func TestBlockService_BlockByIndex(t *testing.T) {
 	networkProvider.MockNumShards = 1
 	extension := newNetworkProviderExtension(networkProvider)
 
+	tx := &transaction.ApiTransactionResult{
+		Hash:             "aaaa",
+		Type:             string(transaction.TxTypeNormal),
+		Sender:           testscommon.TestAddressAlice,
+		Receiver:         testscommon.TestAddressBob,
+		Value:            "1",
+		InitiallyPaidFee: "50000000000000",
+	}
+
 	networkProvider.MockBlocksByNonce[7] = &api.Block{
 		Hash:          "0007",
 		Nonce:         7,
@@ -27,16 +36,7 @@ func TestBlockService_BlockByIndex(t *testing.T) {
 		Status:        "on-chain",
 		MiniBlocks: []*api.MiniBlock{
 			{
-				Transactions: []*transaction.ApiTransactionResult{
-					{
-						Hash:             "aaaa",
-						Type:             string(transaction.TxTypeNormal),
-						Sender:           testscommon.TestAddressAlice,
-						Receiver:         testscommon.TestAddressBob,
-						Value:            "1",
-						InitiallyPaidFee: "50000000000000",
-					},
-				},
+				Transactions: []*transaction.ApiTransactionResult{tx},
 			},
 		},
 	}
@@ -84,6 +84,7 @@ func TestBlockService_BlockByIndex(t *testing.T) {
 						Status:              &opStatusSuccess,
 					},
 				},
+				Metadata: extractTransactionMetadata(tx),
 			},
 		},
 		Metadata: objectsMap{

--- a/server/services/mempoolService_test.go
+++ b/server/services/mempoolService_test.go
@@ -25,7 +25,7 @@ func TestMempoolService_MempoolTransaction(t *testing.T) {
 	extension := newNetworkProviderExtension(networkProvider)
 	service := NewMempoolService(networkProvider)
 
-	networkProvider.MockMempoolTransactionsByHash["aaaa"] = &transaction.ApiTransactionResult{
+	tx := &transaction.ApiTransactionResult{
 		Hash:     "aaaa",
 		Type:     string(transaction.TxTypeNormal),
 		Receiver: testscommon.TestAddressBob,
@@ -34,6 +34,8 @@ func TestMempoolService_MempoolTransaction(t *testing.T) {
 		GasLimit: 50000,
 		GasPrice: 1000000000,
 	}
+
+	networkProvider.MockMempoolTransactionsByHash["aaaa"] = tx
 
 	expectedRosettaTx := &types.Transaction{
 		TransactionIdentifier: hashToTransactionIdentifier("aaaa"),
@@ -51,6 +53,7 @@ func TestMempoolService_MempoolTransaction(t *testing.T) {
 				Amount:              extension.valueToNativeAmount("1234"),
 			},
 		},
+		Metadata: extractTransactionMetadata(tx),
 	}
 
 	txResponse, err := getMempoolTransactionByHash(service, "aaaa")

--- a/server/services/operations.go
+++ b/server/services/operations.go
@@ -15,14 +15,16 @@ const (
 )
 
 var (
-	// SupportedOperationTypes is a list of the supported operations.
+	// SupportedOperationTypes is a list of the supported operations
 	SupportedOperationTypes = []string{
+		opGenesisBalanceMovement,
 		opTransfer,
 		opFee,
 		opReward,
 		opScResult,
+		opFeeRefundAsScResult,
+		opDeveloperRewardsAsScResult,
 		opFeeOfInvalidTx,
-		opGenesisBalanceMovement,
 		opFeeRefund,
 	}
 

--- a/server/services/operations.go
+++ b/server/services/operations.go
@@ -3,13 +3,15 @@ package services
 import "github.com/coinbase/rosetta-sdk-go/types"
 
 const (
-	opGenesisBalanceMovement = "GenesisBalanceMovement"
-	opTransfer               = "Transfer"
-	opFee                    = "Fee"
-	opReward                 = "Reward"
-	opScResult               = "SmartContractResult"
-	opFeeOfInvalidTx         = "FeeOfInvalidTransaction"
-	opFeeRefund              = "FeeRefund"
+	opGenesisBalanceMovement     = "GenesisBalanceMovement"
+	opTransfer                   = "Transfer"
+	opFee                        = "Fee"
+	opReward                     = "Reward"
+	opScResult                   = "SmartContractResult"
+	opFeeRefundAsScResult        = "FeeRefundAsSmartContractResult"
+	opDeveloperRewardsAsScResult = "DeveloperRewardsAsSmartContractResult"
+	opFeeOfInvalidTx             = "FeeOfInvalidTransaction"
+	opFeeRefund                  = "FeeRefund"
 )
 
 var (

--- a/server/services/transactionMetadata.go
+++ b/server/services/transactionMetadata.go
@@ -22,10 +22,10 @@ func extractTransactionMetadata(tx *transaction.ApiTransactionResult) objectsMap
 		metadata["originalSender"] = tx.OriginalSender
 	}
 	if len(tx.SenderUsername) > 0 {
-		metadata["senderUsername"] = tx.SenderUsername
+		metadata["senderUsername"] = string(tx.SenderUsername)
 	}
 	if len(tx.ReceiverUsername) > 0 {
-		metadata["receiverUsername"] = tx.ReceiverUsername
+		metadata["receiverUsername"] = string(tx.ReceiverUsername)
 	}
 	if len(tx.OriginalTransactionHash) > 0 {
 		metadata["originalTransaction"] = tx.OriginalTransactionHash

--- a/server/services/transactionMetadata.go
+++ b/server/services/transactionMetadata.go
@@ -1,0 +1,47 @@
+package services
+
+import "github.com/ElrondNetwork/elrond-go-core/data/transaction"
+
+func extractTransactionMetadata(tx *transaction.ApiTransactionResult) objectsMap {
+	metadata := objectsMap{
+		"timestamp":         tx.Timestamp,
+		"value":             tx.Value,
+		"nonce":             tx.Nonce,
+		"typeOnSource":      tx.ProcessingTypeOnSource,
+		"typeOnDestination": tx.ProcessingTypeOnDestination,
+		"epoch":             tx.Epoch,
+		"sender":            tx.Sender,
+		"receiver":          tx.Receiver,
+		"sourceShard":       tx.SourceShard,
+		"destinationShard":  tx.DestinationShard,
+		"miniblock":         tx.MiniBlockHash,
+		"miniblockType":     tx.MiniBlockType,
+	}
+
+	if len(tx.OriginalSender) > 0 {
+		metadata["originalSender"] = tx.OriginalSender
+	}
+	if len(tx.SenderUsername) > 0 {
+		metadata["senderUsername"] = tx.SenderUsername
+	}
+	if len(tx.ReceiverUsername) > 0 {
+		metadata["receiverUsername"] = tx.ReceiverUsername
+	}
+	if len(tx.OriginalTransactionHash) > 0 {
+		metadata["originalTransaction"] = tx.OriginalTransactionHash
+	}
+	if len(tx.PreviousTransactionHash) > 0 {
+		metadata["previousTransaction"] = tx.PreviousTransactionHash
+	}
+	if len(tx.Data) > 0 {
+		metadata["data"] = tx.Data
+	}
+	if tx.GasPrice > 0 {
+		metadata["gasPrice"] = tx.GasPrice
+	}
+	if tx.GasLimit > 0 {
+		metadata["gasLimit"] = tx.GasLimit
+	}
+
+	return metadata
+}

--- a/server/services/transactionMetadata_test.go
+++ b/server/services/transactionMetadata_test.go
@@ -1,0 +1,62 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractTransactionMetadata(t *testing.T) {
+	tx := &transaction.ApiTransactionResult{
+		Timestamp:                   1000,
+		Value:                       "1001",
+		Nonce:                       1002,
+		ProcessingTypeOnSource:      "a",
+		ProcessingTypeOnDestination: "b",
+		Epoch:                       1003,
+		Sender:                      "alice",
+		Receiver:                    "bob",
+		SourceShard:                 7,
+		DestinationShard:            8,
+		MiniBlockHash:               "abba",
+		MiniBlockType:               "foo",
+	}
+
+	expectedMetadata := objectsMap{
+		"timestamp":         int64(1000),
+		"value":             "1001",
+		"nonce":             uint64(1002),
+		"typeOnSource":      "a",
+		"typeOnDestination": "b",
+		"epoch":             uint32(1003),
+		"sender":            "alice",
+		"receiver":          "bob",
+		"sourceShard":       uint32(7),
+		"destinationShard":  uint32(8),
+		"miniblock":         "abba",
+		"miniblockType":     "foo",
+	}
+
+	require.Equal(t, expectedMetadata, extractTransactionMetadata(tx))
+
+	tx.OriginalSender = "alice"
+	tx.SenderUsername = []byte("alice")
+	tx.ReceiverUsername = []byte("bob")
+	tx.OriginalTransactionHash = "aaaa"
+	tx.PreviousTransactionHash = "bbbb"
+	tx.Data = []byte("test")
+	tx.GasPrice = 42
+	tx.GasLimit = 43
+
+	expectedMetadata["originalSender"] = "alice"
+	expectedMetadata["senderUsername"] = "alice"
+	expectedMetadata["receiverUsername"] = "bob"
+	expectedMetadata["originalTransaction"] = "aaaa"
+	expectedMetadata["previousTransaction"] = "bbbb"
+	expectedMetadata["data"] = []byte("test")
+	expectedMetadata["gasPrice"] = uint64(42)
+	expectedMetadata["gasLimit"] = uint64(43)
+
+	require.Equal(t, expectedMetadata, extractTransactionMetadata(tx))
+}

--- a/server/services/transactionsTransformer.go
+++ b/server/services/transactionsTransformer.go
@@ -115,7 +115,7 @@ func (transformer *transactionsTransformer) unsignedTxToRosettaTx(
 			TransactionIdentifier: hashToTransactionIdentifier(scr.Hash),
 			Operations: []*types.Operation{
 				{
-					Type:    opScResult,
+					Type:    opFeeRefundAsScResult,
 					Account: addressToAccountIdentifier(scr.Receiver),
 					Amount:  transformer.extension.valueToNativeAmount(scr.Value),
 				},
@@ -128,7 +128,7 @@ func (transformer *transactionsTransformer) unsignedTxToRosettaTx(
 			TransactionIdentifier: hashToTransactionIdentifier(scr.Hash),
 			Operations: []*types.Operation{
 				{
-					Type:    opScResult,
+					Type:    opDeveloperRewardsAsScResult,
 					Account: addressToAccountIdentifier(scr.Receiver),
 					Amount:  transformer.extension.valueToNativeAmount(scr.Value),
 				},
@@ -150,6 +150,7 @@ func (transformer *transactionsTransformer) unsignedTxToRosettaTx(
 				Amount:  transformer.extension.valueToNativeAmount(scr.Value),
 			},
 		},
+		Metadata: extractTransactionMetadata(scr),
 	}
 }
 
@@ -193,6 +194,7 @@ func (transformer *transactionsTransformer) moveBalanceTxToRosetta(tx *transacti
 	return &types.Transaction{
 		TransactionIdentifier: hashToTransactionIdentifier(tx.Hash),
 		Operations:            operations,
+		Metadata:              extractTransactionMetadata(tx),
 	}
 }
 
@@ -246,6 +248,7 @@ func (transformer *transactionsTransformer) invalidTxToRosettaTx(tx *transaction
 				Amount:  transformer.extension.valueToNativeAmount("-" + fee),
 			},
 		},
+		Metadata: extractTransactionMetadata(tx),
 	}
 }
 
@@ -272,6 +275,7 @@ func (transformer *transactionsTransformer) mempoolMoveBalanceTxToRosettaTx(tx *
 	return &types.Transaction{
 		TransactionIdentifier: hashToTransactionIdentifier(tx.Hash),
 		Operations:            operations,
+		Metadata:              extractTransactionMetadata(tx),
 	}
 }
 

--- a/server/services/transactionsTransformer_test.go
+++ b/server/services/transactionsTransformer_test.go
@@ -28,7 +28,7 @@ func TestTransactionsTransformer_UnsignedTxToRosettaTx(t *testing.T) {
 		TransactionIdentifier: hashToTransactionIdentifier("aaaa"),
 		Operations: []*types.Operation{
 			{
-				Type:    opScResult,
+				Type:    opFeeRefundAsScResult,
 				Account: addressToAccountIdentifier(testscommon.TestAddressAlice),
 				Amount:  extension.valueToNativeAmount("1234"),
 			},
@@ -56,6 +56,7 @@ func TestTransactionsTransformer_UnsignedTxToRosettaTx(t *testing.T) {
 				Amount:  extension.valueToNativeAmount("1234"),
 			},
 		},
+		Metadata: extractTransactionMetadata(moveBalanceTx),
 	}
 
 	txsInBlock := []*transaction.ApiTransactionResult{refundTx, moveBalanceTx}
@@ -101,6 +102,7 @@ func TestTransactionsTransformer_InvalidTxToRosettaTx(t *testing.T) {
 				Amount:  extension.valueToNativeAmount("-50000000000000"),
 			},
 		},
+		Metadata: extractTransactionMetadata(tx),
 	}
 
 	rosettaTx := transformer.invalidTxToRosettaTx(tx)

--- a/version/constants.go
+++ b/version/constants.go
@@ -5,9 +5,9 @@ const (
 	RosettaVersion = "v1.4.12"
 
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.2.7"
+	RosettaMiddlewareVersion = "v0.2.8"
 
 	// NodeVersion is the canonical version of the node runtime
 	// TODO: We should fetch this from node/status.
-	NodeVersion = "v1.3.42-rosetta1"
+	NodeVersion = "v1.3.43-rosetta1"
 )


### PR DESCRIPTION
 - Add [transaction metadata](https://www.rosetta-api.org/docs/models/Transaction.html): 

```
{
	"timestamp":         ...,
	"value":             ...,
	"nonce":             ...,
	"typeOnSource":      ...,
	"typeOnDestination": ...,
	"epoch":             ...,
	"sender":            ...,
	"receiver":          ...,
	"sourceShard":       ...,
	"destinationShard":  ...,
	"miniblock":         ...,
	"miniblockType":     ...,
	...
}
```

 - Add new operation types, to better differentiate operations: `FeeRefundAsSmartContractResult`, `DeveloperRewardsAsSmartContractResult`.

- Improve error handling for `network/status`, when `highestFinalNonce == 0` (node didn't start syncing).

