### PR TITLE
Use interface{} instead of "any" (go 1.17).

### DIFF
--- a/server/services/common.go
+++ b/server/services/common.go
@@ -8,7 +8,7 @@ import (
 
 type objectsMap map[string]interface{}
 
-func toObjectsMap(value any) (objectsMap, error) {
+func toObjectsMap(value interface{}) (objectsMap, error) {
 	data, err := json.Marshal(value)
 	if err != nil {
 		return nil, err
@@ -23,7 +23,7 @@ func toObjectsMap(value any) (objectsMap, error) {
 	return result, nil
 }
 
-func fromObjectsMap(obj objectsMap, value any) error {
+func fromObjectsMap(obj objectsMap, value interface{}) error {
 	data, err := json.Marshal(obj)
 	if err != nil {
 		return err


### PR DESCRIPTION
 - Use `interface{}` instead of `any` - since we use `go 1.17` on [rosetta-docker](https://github.com/ElrondNetwork/rosetta-docker).