### PR TITLE
Get extra details from node/status and return them in Rosetta API

### DIFF
--- a/cmd/rosetta/cli.go
+++ b/cmd/rosetta/cli.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"strings"
-
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/urfave/cli"
 )
@@ -66,12 +64,6 @@ VERSION:
 		Name:  "observer-http-url",
 		Usage: "Specifies the URL of the observer.",
 		Value: "http://nowhere.localhost.local",
-	}
-
-	cliFlagObserverPubKey = cli.StringFlag{
-		Name:  "observer-pubkey",
-		Usage: "Specifies the public key of the observer.",
-		Value: strings.Repeat("0", 64),
 	}
 
 	cliFlagNetworkID = cli.StringFlag{
@@ -150,7 +142,6 @@ func getAllCliFlags() []cli.Flag {
 		cliFlagObserverActualShard,
 		cliFlagObserverProjectedShard,
 		cliFlagObserverHttpUrl,
-		cliFlagObserverPubKey,
 		cliFlagNetworkID,
 		cliFlagNetworkName,
 		cliFlagNumShards,
@@ -174,7 +165,6 @@ type parsedCliFlags struct {
 	observerProjectedShard      uint32
 	observerProjectedShardIsSet bool
 	observerHttpUrl             string
-	observerPubkey              string
 	networkID                   string
 	networkName                 string
 	numShards                   uint32
@@ -198,7 +188,6 @@ func getParsedCliFlags(ctx *cli.Context) parsedCliFlags {
 		observerProjectedShard:      uint32(ctx.GlobalUint(cliFlagObserverProjectedShard.Name)),
 		observerProjectedShardIsSet: ctx.GlobalIsSet(cliFlagObserverProjectedShard.Name),
 		observerHttpUrl:             ctx.GlobalString(cliFlagObserverHttpUrl.Name),
-		observerPubkey:              ctx.GlobalString(cliFlagObserverPubKey.Name),
 		networkID:                   ctx.GlobalString(cliFlagNetworkID.Name),
 		networkName:                 ctx.GlobalString(cliFlagNetworkName.Name),
 		numShards:                   uint32(ctx.GlobalUint(cliFlagNumShards.Name)),

--- a/cmd/rosetta/main.go
+++ b/cmd/rosetta/main.go
@@ -53,7 +53,7 @@ func startRosetta(ctx *cli.Context) error {
 		return err
 	}
 
-	log.Info("Starting Rosetta...", "middleware", version.RosettaMiddlewareVersion, "specification", version.RosettaVersion, "node", version.NodeVersion)
+	log.Info("Starting Rosetta...", "middleware", version.RosettaMiddlewareVersion, "specification", version.RosettaVersion)
 
 	networkProvider, err := factory.CreateNetworkProvider(factory.ArgsCreateNetworkProvider{
 		IsOffline:                   cliFlags.offline,

--- a/cmd/rosetta/main.go
+++ b/cmd/rosetta/main.go
@@ -62,7 +62,6 @@ func startRosetta(ctx *cli.Context) error {
 		ObservedProjectedShard:      cliFlags.observerProjectedShard,
 		ObservedProjectedShardIsSet: cliFlags.observerProjectedShardIsSet,
 		ObserverUrl:                 cliFlags.observerHttpUrl,
-		ObserverPubkey:              cliFlags.observerPubkey,
 		NetworkID:                   cliFlags.networkID,
 		NetworkName:                 cliFlags.networkName,
 		GasPerDataByte:              cliFlags.gasPerDataByte,

--- a/server/factory/interface.go
+++ b/server/factory/interface.go
@@ -14,7 +14,6 @@ type NetworkProvider interface {
 	IsOffline() bool
 	GetBlockchainName() string
 	GetNativeCurrency() resources.NativeCurrency
-	GetObserverPubkey() string
 	GetNetworkConfig() *resources.NetworkConfig
 	GetGenesisBlockSummary() *resources.BlockSummary
 	GetGenesisTimestamp() int64

--- a/server/factory/provider.go
+++ b/server/factory/provider.go
@@ -31,7 +31,6 @@ type ArgsCreateNetworkProvider struct {
 	ObservedProjectedShard      uint32
 	ObservedProjectedShardIsSet bool
 	ObserverUrl                 string
-	ObserverPubkey              string
 	NetworkID                   string
 	NetworkName                 string
 	GasPerDataByte              uint64
@@ -117,7 +116,6 @@ func CreateNetworkProvider(args ArgsCreateNetworkProvider) (NetworkProvider, err
 		ObservedProjectedShard:      args.ObservedProjectedShard,
 		ObservedProjectedShardIsSet: args.ObservedProjectedShardIsSet,
 		ObserverUrl:                 args.ObserverUrl,
-		ObserverPubkey:              args.ObserverPubkey,
 		NetworkID:                   args.NetworkID,
 		NetworkName:                 args.NetworkName,
 		GasPerDataByte:              args.GasPerDataByte,

--- a/server/provider/networkProvider.go
+++ b/server/provider/networkProvider.go
@@ -26,7 +26,6 @@ type ArgsNewNetworkProvider struct {
 	ObservedProjectedShard      uint32
 	ObservedProjectedShardIsSet bool
 	ObserverUrl                 string
-	ObserverPubkey              string
 	NetworkID                   string
 	NetworkName                 string
 	GasPerDataByte              uint64
@@ -51,7 +50,6 @@ type networkProvider struct {
 	observedProjectedShard      uint32
 	observedProjectedShardIsSet bool
 	observerUrl                 string
-	observerPubkey              string
 	nativeCurrencySymbol        string
 	genesisBlockHash            string
 	genesisTimestamp            int64
@@ -84,7 +82,6 @@ func NewNetworkProvider(args ArgsNewNetworkProvider) (*networkProvider, error) {
 		observedProjectedShard:      args.ObservedProjectedShard,
 		observedProjectedShardIsSet: args.ObservedProjectedShardIsSet,
 		observerUrl:                 args.ObserverUrl,
-		observerPubkey:              args.ObserverPubkey,
 		nativeCurrencySymbol:        args.NativeCurrencySymbol,
 		genesisBlockHash:            args.GenesisBlockHash,
 		genesisTimestamp:            args.GenesisTimestamp,
@@ -125,11 +122,6 @@ func (provider *networkProvider) GetNativeCurrency() resources.NativeCurrency {
 		Symbol:   provider.nativeCurrencySymbol,
 		Decimals: int32(nativeCurrencyNumDecimals),
 	}
-}
-
-// GetObserverPubkey gets the pubkey of the connected observer
-func (provider *networkProvider) GetObserverPubkey() string {
-	return provider.observerPubkey
 }
 
 // GetNetworkConfig gets the network config (once fetched, the network config is indefinitely held in memory)

--- a/server/provider/networkProvider_test.go
+++ b/server/provider/networkProvider_test.go
@@ -20,7 +20,6 @@ func TestNewNetworkProvider(t *testing.T) {
 		ObservedProjectedShard:      42,
 		ObservedProjectedShardIsSet: true,
 		ObserverUrl:                 "http://my-observer:8080",
-		ObserverPubkey:              "abba",
 		NetworkID:                   "T",
 		NetworkName:                 "testnet",
 		GasPerDataByte:              1501,
@@ -46,7 +45,6 @@ func TestNewNetworkProvider(t *testing.T) {
 	assert.Equal(t, uint32(42), provider.observedProjectedShard)
 	assert.Equal(t, true, provider.observedProjectedShardIsSet)
 	assert.Equal(t, "http://my-observer:8080", provider.observerUrl)
-	assert.Equal(t, "abba", provider.GetObserverPubkey())
 	assert.Equal(t, "T", provider.GetNetworkConfig().NetworkID)
 	assert.Equal(t, "testnet", provider.GetNetworkConfig().NetworkName)
 	assert.Equal(t, uint64(1501), provider.GetNetworkConfig().GasPerDataByte)
@@ -173,7 +171,6 @@ func createDefaultArgsNewNetworkProvider() ArgsNewNetworkProvider {
 		ObservedProjectedShard:      0,
 		ObservedProjectedShardIsSet: false,
 		ObserverUrl:                 "http://my-observer:8080",
-		ObserverPubkey:              "MY-OBSERVER",
 		NetworkID:                   "T",
 		GasPerDataByte:              1500,
 		MinGasPrice:                 1000000000,

--- a/server/provider/nodeStatus.go
+++ b/server/provider/nodeStatus.go
@@ -45,7 +45,6 @@ func (provider *networkProvider) GetNodeStatus() (*resources.AggregatedNodeStatu
 		ConnectedPeersCounts:           peersCounts,
 		ObserverPublicKey:              plainNodeStatus.ObserverPublicKey,
 		Synced:                         plainNodeStatus.IsSyncing == 0,
-		CurrentEpoch:                   plainNodeStatus.CurrentEpoch,
 		LatestBlock:                    latestBlockSummary,
 		OldestBlockWithHistoricalState: oldestBlockWithHistoricalState,
 	}, nil

--- a/server/provider/nodeStatus_test.go
+++ b/server/provider/nodeStatus_test.go
@@ -29,10 +29,13 @@ func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
 		if path == "/node/status" {
 			value.(*resources.NodeStatusApiResponse).Data = resources.NodeStatusApiResponsePayload{
 				Status: resources.NodeStatus{
-					IsSyncing:         1,
-					HighestNonce:      1005,
-					HighestFinalNonce: 1000,
-					CurrentEpoch:      11,
+					Version:              "v1.2.3",
+					ObserverPublicKey:    "abba",
+					ConnectedPeersCounts: "intraVal:0,crossVal:3,intraObs:1,crossObs:3,fullObs:2,unknown:0,",
+					IsSyncing:            1,
+					HighestNonce:         1005,
+					HighestFinalNonce:    1000,
+					CurrentEpoch:         11,
 				},
 			}
 
@@ -85,6 +88,15 @@ func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
 		return nil, errors.New("unexpected request")
 	}
 
+	expectedPeersCounts := map[string]int{
+		"intraVal": 0,
+		"crossVal": 3,
+		"intraObs": 1,
+		"crossObs": 3,
+		"fullObs":  2,
+		"unknown":  0,
+	}
+
 	expectedSummaryOfLatest := resources.BlockSummary{
 		Nonce:             998,
 		Hash:              "00000998",
@@ -101,7 +113,11 @@ func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
 
 	nodeStatus, err := provider.GetNodeStatus()
 	require.Nil(t, err)
+	require.Equal(t, "v1.2.3", nodeStatus.Version)
+	require.Equal(t, "abba", nodeStatus.ObserverPublicKey)
+	require.Equal(t, expectedPeersCounts, nodeStatus.ConnectedPeersCounts)
 	require.False(t, nodeStatus.Synced)
+	require.Equal(t, uint32(11), nodeStatus.CurrentEpoch)
 	require.Equal(t, expectedSummaryOfLatest, nodeStatus.LatestBlock)
 	require.Equal(t, expectedSummaryOfOldest, nodeStatus.OldestBlockWithHistoricalState)
 }

--- a/server/provider/nodeStatus_test.go
+++ b/server/provider/nodeStatus_test.go
@@ -298,3 +298,43 @@ func TestGetOldestEligibleEpoch(t *testing.T) {
 	epoch = provider.getOldestEligibleEpoch(100)
 	require.Equal(t, uint32(92), epoch)
 }
+
+func TestParsePeersCounts(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		map[string]int{
+			"intraVal": 0,
+			"crossVal": 3,
+			"intraObs": 1,
+			"crossObs": 3,
+			"fullObs":  2,
+			"unknown":  0,
+		},
+		parsePeersCounts("intraVal:0,crossVal:3,intraObs:1,crossObs:3,fullObs:2,unknown:0,"),
+	)
+
+	require.Equal(t,
+		map[string]int{
+			"intraObs": 1,
+			"crossObs": 3,
+			"fullObs":  2,
+			"unknown":  0,
+		},
+		parsePeersCounts("intraVal:0?crossVal:3,intraObs:1,crossObs:3,fullObs:2,unknown:0,"),
+	)
+
+	require.Equal(t,
+		map[string]int{
+			"crossObs": 3,
+			"fullObs":  2,
+			"unknown":  0,
+		},
+		parsePeersCounts("intraVal:0?crossVal:3,intraObs?1,crossObs:3,fullObs:2,unknown:0,"),
+	)
+
+	require.Equal(t,
+		map[string]int{},
+		parsePeersCounts(""),
+	)
+}

--- a/server/provider/nodeStatus_test.go
+++ b/server/provider/nodeStatus_test.go
@@ -117,7 +117,6 @@ func TestNetworkProvider_GetNodeStatusWithSuccess(t *testing.T) {
 	require.Equal(t, "abba", nodeStatus.ObserverPublicKey)
 	require.Equal(t, expectedPeersCounts, nodeStatus.ConnectedPeersCounts)
 	require.False(t, nodeStatus.Synced)
-	require.Equal(t, uint32(11), nodeStatus.CurrentEpoch)
 	require.Equal(t, expectedSummaryOfLatest, nodeStatus.LatestBlock)
 	require.Equal(t, expectedSummaryOfOldest, nodeStatus.OldestBlockWithHistoricalState)
 }

--- a/server/resources/network.go
+++ b/server/resources/network.go
@@ -53,7 +53,6 @@ type AggregatedNodeStatus struct {
 	ConnectedPeersCounts           map[string]int
 	ObserverPublicKey              string
 	Synced                         bool
-	CurrentEpoch                   uint32
 	LatestBlock                    BlockSummary
 	OldestBlockWithHistoricalState BlockSummary
 }

--- a/server/resources/network.go
+++ b/server/resources/network.go
@@ -22,10 +22,13 @@ type NodeStatusApiResponsePayload struct {
 
 // NodeStatus is an API resource
 type NodeStatus struct {
-	IsSyncing         int    `json:"erd_is_syncing"`
-	HighestNonce      uint64 `json:"erd_nonce"`
-	HighestFinalNonce uint64 `json:"erd_highest_final_nonce"`
-	CurrentEpoch      uint32 `json:"erd_epoch_number"`
+	Version              string `json:"erd_app_version"`
+	ConnectedPeersCounts string `json:"erd_num_connected_peers_classification"`
+	ObserverPublicKey    string `json:"erd_public_key_block_sign"`
+	IsSyncing            int    `json:"erd_is_syncing"`
+	CurrentEpoch         uint32 `json:"erd_epoch_number"`
+	HighestNonce         uint64 `json:"erd_nonce"`
+	HighestFinalNonce    uint64 `json:"erd_highest_final_nonce"`
 }
 
 // EpochStartApiResponse is an API resource
@@ -46,7 +49,11 @@ type EpochStart struct {
 
 // AggregatedNodeStatus is an aggregated resource
 type AggregatedNodeStatus struct {
+	Version                        string
+	ConnectedPeersCounts           map[string]int
+	ObserverPublicKey              string
 	Synced                         bool
+	CurrentEpoch                   uint32
 	LatestBlock                    BlockSummary
 	OldestBlockWithHistoricalState BlockSummary
 }

--- a/server/services/constants.go
+++ b/server/services/constants.go
@@ -14,6 +14,7 @@ var (
 	refundGasMessage                             = "refundedGas"
 	sendingValueToNonPayableContractDataPrefix   = "@" + hex.EncodeToString([]byte("sending value to non payable contract"))
 	emptyHash                                    = strings.Repeat("0", 64)
+	nodeVersionForOfflineRosetta                 = "N / A"
 )
 
 var (

--- a/server/services/interface.go
+++ b/server/services/interface.go
@@ -13,7 +13,6 @@ type NetworkProvider interface {
 	IsOffline() bool
 	GetBlockchainName() string
 	GetNativeCurrency() resources.NativeCurrency
-	GetObserverPubkey() string
 	GetNetworkConfig() *resources.NetworkConfig
 	GetGenesisBlockSummary() *resources.BlockSummary
 	GetGenesisTimestamp() int64

--- a/server/services/networkService.go
+++ b/server/services/networkService.go
@@ -66,6 +66,7 @@ func (service *networkService) NetworkStatus(
 			{
 				PeerID: nodeStatus.ObserverPublicKey,
 				Metadata: objectsMap{
+					"version":     nodeStatus.Version,
 					"connections": nodeStatus.ConnectedPeersCounts,
 				},
 			},

--- a/server/services/networkService.go
+++ b/server/services/networkService.go
@@ -103,7 +103,7 @@ func (service *networkService) NetworkOptions(
 func (service *networkService) getNodeVersion() (string, *types.Error) {
 	if service.provider.IsOffline() {
 		// In offline mode, Rosetta does not interact with the Node.
-		return "N / A", nil
+		return nodeVersionForOfflineRosetta, nil
 	}
 
 	nodeStatus, err := service.provider.GetNodeStatus()

--- a/server/services/networkService_test.go
+++ b/server/services/networkService_test.go
@@ -48,6 +48,7 @@ func TestNetworkService_NetworkOptions(t *testing.T) {
 func TestNetworkService_NetworkStatus(t *testing.T) {
 	networkProvider := testscommon.NewNetworkProviderMock()
 	networkProvider.MockGenesisBlockHash = "genesisHash"
+	networkProvider.MockNodeStatus.Version = "v1.2.3"
 	networkProvider.MockNodeStatus.LatestBlock.Nonce = 42
 	networkProvider.MockNodeStatus.LatestBlock.Hash = "latestHash"
 	networkProvider.MockNodeStatus.LatestBlock.Timestamp = 123456789
@@ -86,6 +87,7 @@ func TestNetworkService_NetworkStatus(t *testing.T) {
 			{
 				PeerID: "abba",
 				Metadata: objectsMap{
+					"version": "v1.2.3",
 					"connections": map[string]int{
 						"fullObs":  2,
 						"intraObs": 3,

--- a/server/services/networkService_test.go
+++ b/server/services/networkService_test.go
@@ -26,6 +26,7 @@ func TestNetworkService_NetworkList(t *testing.T) {
 
 func TestNetworkService_NetworkOptions(t *testing.T) {
 	networkProvider := testscommon.NewNetworkProviderMock()
+	networkProvider.MockNodeStatus.Version = "v1.2.3"
 	service := NewNetworkService(networkProvider)
 
 	networkOptions, err := service.NetworkOptions(context.Background(), nil)
@@ -33,7 +34,7 @@ func TestNetworkService_NetworkOptions(t *testing.T) {
 	require.Equal(t, &types.NetworkOptionsResponse{
 		Version: &types.Version{
 			RosettaVersion: version.RosettaVersion,
-			NodeVersion:    version.NodeVersion,
+			NodeVersion:    "v1.2.3",
 		},
 		Allow: &types.Allow{
 			HistoricalBalanceLookup: true,
@@ -46,7 +47,6 @@ func TestNetworkService_NetworkOptions(t *testing.T) {
 
 func TestNetworkService_NetworkStatus(t *testing.T) {
 	networkProvider := testscommon.NewNetworkProviderMock()
-	networkProvider.MockObserverPubkey = "my-computer"
 	networkProvider.MockGenesisBlockHash = "genesisHash"
 	networkProvider.MockNodeStatus.LatestBlock.Nonce = 42
 	networkProvider.MockNodeStatus.LatestBlock.Hash = "latestHash"
@@ -54,6 +54,11 @@ func TestNetworkService_NetworkStatus(t *testing.T) {
 	networkProvider.MockNodeStatus.OldestBlockWithHistoricalState.Nonce = 7
 	networkProvider.MockNodeStatus.OldestBlockWithHistoricalState.Hash = "oldestHash"
 	networkProvider.MockNodeStatus.Synced = true
+	networkProvider.MockNodeStatus.ObserverPublicKey = "abba"
+	networkProvider.MockNodeStatus.ConnectedPeersCounts = map[string]int{
+		"fullObs":  2,
+		"intraObs": 3,
+	}
 
 	service := NewNetworkService(networkProvider)
 
@@ -79,7 +84,13 @@ func TestNetworkService_NetworkStatus(t *testing.T) {
 		},
 		Peers: []*types.Peer{
 			{
-				PeerID: "my-computer",
+				PeerID: "abba",
+				Metadata: objectsMap{
+					"connections": map[string]int{
+						"fullObs":  2,
+						"intraObs": 3,
+					},
+				},
 			},
 		},
 	}, networkStatusResponse)

--- a/testscommon/networkProviderMock.go
+++ b/testscommon/networkProviderMock.go
@@ -27,7 +27,6 @@ type networkProviderMock struct {
 	MockObservedActualShard         uint32
 	MockObservedProjectedShard      uint32
 	MockObservedProjectedShardIsSet bool
-	MockObserverPubkey              string
 	MockNativeCurrencySymbol        string
 	MockGenesisBlockHash            string
 	MockGenesisTimestamp            int64
@@ -59,7 +58,6 @@ func NewNetworkProviderMock() *networkProviderMock {
 		MockObservedActualShard:         0,
 		MockObservedProjectedShard:      0,
 		MockObservedProjectedShardIsSet: false,
-		MockObserverPubkey:              "observer",
 		MockNativeCurrencySymbol:        "XeGLD",
 		MockGenesisBlockHash:            emptyHash,
 		MockGenesisTimestamp:            genesisTimestamp,
@@ -118,11 +116,6 @@ func (mock *networkProviderMock) GetNativeCurrency() resources.NativeCurrency {
 		Symbol:   mock.MockNativeCurrencySymbol,
 		Decimals: 18,
 	}
-}
-
-// GetObserverPubkey -
-func (mock *networkProviderMock) GetObserverPubkey() string {
-	return mock.MockObserverPubkey
 }
 
 // GetNetworkConfig -

--- a/version/constants.go
+++ b/version/constants.go
@@ -5,9 +5,5 @@ const (
 	RosettaVersion = "v1.4.12"
 
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.3.0"
-
-	// NodeVersion is the canonical version of the node runtime
-	// TODO: We should fetch this from node/status.
-	NodeVersion = "v1.3.44-rosetta1"
+	RosettaMiddlewareVersion = "v0.3.1"
 )


### PR DESCRIPTION
 - the CLI flag `--observer-pubkey` has been removed. Observer's public key (BLS) is now returned in `/network/status` (peers substructure).
 - Observer's version isn't hardcoded anymore in `version/constants.go`. Instead, it's fetched from the Observer's API. Rosetta's `/network/options` and `/network/status` now return this version.
 - peer connections statistics (counts) are now returned in `/network/status`.