### PR TITLE
Add middleware version in response of "/network/options".

### DIFF
--- a/server/services/networkService.go
+++ b/server/services/networkService.go
@@ -88,8 +88,9 @@ func (service *networkService) NetworkOptions(
 
 	return &types.NetworkOptionsResponse{
 		Version: &types.Version{
-			RosettaVersion: version.RosettaVersion,
-			NodeVersion:    nodeVersion,
+			RosettaVersion:    version.RosettaVersion,
+			MiddlewareVersion: &version.RosettaMiddlewareVersion,
+			NodeVersion:       nodeVersion,
 		},
 		Allow: &types.Allow{
 			OperationStatuses:       supportedOperationStatuses,

--- a/server/services/networkService_test.go
+++ b/server/services/networkService_test.go
@@ -33,8 +33,9 @@ func TestNetworkService_NetworkOptions(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, &types.NetworkOptionsResponse{
 		Version: &types.Version{
-			RosettaVersion: version.RosettaVersion,
-			NodeVersion:    "v1.2.3",
+			RosettaVersion:    version.RosettaVersion,
+			MiddlewareVersion: &version.RosettaMiddlewareVersion,
+			NodeVersion:       "v1.2.3",
 		},
 		Allow: &types.Allow{
 			HistoricalBalanceLookup: true,

--- a/version/constants.go
+++ b/version/constants.go
@@ -3,7 +3,9 @@ package version
 const (
 	// RosettaVersion is the version of the Rosetta interface the implementation adheres to.
 	RosettaVersion = "v1.4.12"
+)
 
+var (
 	// RosettaMiddlewareVersion is the version of this package (application)
 	RosettaMiddlewareVersion = "v0.3.1"
 )


### PR DESCRIPTION
Return middleware version, as well, in the response of `/network/options`.

See: https://www.rosetta-api.org/docs/models/Version.html

Example:

```
{
    "version": {
        "rosetta_version": "v1.4.12",
        "node_version": "v1.3.48-devnet-hf01-0-g67d0313/go1.17.6/linux-amd64/f9b031042e",
        "middleware_version": "v0.3.1"
    },
...
}
```