### PR TITLE
(Low-impact) handle "meta transaction is invalid: not enough gas"

### DIFF
--- a/server/services/constants.go
+++ b/server/services/constants.go
@@ -18,7 +18,8 @@ var (
 )
 
 var (
-	transactionEventSignalError                 = "signalError"
-	transactionEventTransferValueOnly           = "transferValueOnly"
-	transactionEventTopicInvalidMetaTransaction = "meta transaction is invalid"
+	transactionEventSignalError                             = "signalError"
+	transactionEventTransferValueOnly                       = "transferValueOnly"
+	transactionEventTopicInvalidMetaTransaction             = "meta transaction is invalid"
+	transactionEventTopicInvalidMetaTransactionNotEnoughGas = "meta transaction is invalid: not enough gas"
 )

--- a/server/services/transactionEventsController.go
+++ b/server/services/transactionEventsController.go
@@ -87,8 +87,10 @@ func (controller *transactionEventsController) hasSignalErrorOfMetaTransactionIs
 			continue
 		}
 
-		hasTopicInvalidMetaTransaction := eventHasTopic(event, transactionEventTopicInvalidMetaTransaction)
-		if hasTopicInvalidMetaTransaction {
+		if eventHasTopic(event, transactionEventTopicInvalidMetaTransaction) {
+			return true
+		}
+		if eventHasTopic(event, transactionEventTopicInvalidMetaTransactionNotEnoughGas) {
 			return true
 		}
 	}

--- a/server/services/transactionEventsController_test.go
+++ b/server/services/transactionEventsController_test.go
@@ -46,7 +46,7 @@ func TestTransactionEventsController_HasSignalErrorOfMetaTransactionIsInvalid(t 
 		require.False(t, txMatches)
 	})
 
-	t.Run("invalid tx with event 'invalid meta transaction'", func(t *testing.T) {
+	t.Run("invalid tx with event 'meta transaction is invalid'", func(t *testing.T) {
 		tx := &transaction.ApiTransactionResult{
 			Logs: &transaction.ApiLogs{
 
@@ -55,6 +55,25 @@ func TestTransactionEventsController_HasSignalErrorOfMetaTransactionIsInvalid(t 
 						Identifier: transactionEventSignalError,
 						Topics: [][]byte{
 							[]byte(transactionEventTopicInvalidMetaTransaction),
+						},
+					},
+				},
+			},
+		}
+
+		txMatches := controller.hasSignalErrorOfMetaTransactionIsInvalid(tx)
+		require.True(t, txMatches)
+	})
+
+	t.Run("invalid tx with event 'meta transaction is invalid: not enough gas'", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			Logs: &transaction.ApiLogs{
+
+				Events: []*transaction.Events{
+					{
+						Identifier: transactionEventSignalError,
+						Topics: [][]byte{
+							[]byte(transactionEventTopicInvalidMetaTransactionNotEnoughGas),
 						},
 					},
 				},

--- a/version/constants.go
+++ b/version/constants.go
@@ -7,5 +7,5 @@ const (
 
 var (
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.3.4"
+	RosettaMiddlewareVersion = "v0.3.5"
 )


### PR DESCRIPTION
Adjust fee handling for invalid / intrashard transactions of type `MoveBalance` (at both _source_ and _destination_).